### PR TITLE
feat: Initial import of public NTP servers and generation scripts

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,6 +34,8 @@ jobs:
           disable-telemetry: true
           allowed-endpoints: 
             api.github.com:443
+            api0.prismacloud.io:443
+            files.pythonhosted.org:443
             github.com:443
             proxy.golang.org:443
             pypi.org:443

--- a/README.md
+++ b/README.md
@@ -1,13 +1,348 @@
-# ghafiles
+# Public NTP Servers
 
-This contains baseline GitHub Actions that may be useful for any new project. 
+This repository lists public NTP (Network Time Protocol) servers.
+The list is sourced from various public resources and aims to provide configuration files for common NTP clients.
 
-- Adhere to least privilege principles for workflow permissions
-- Use of commit hashes for pinning GitHub Actions dependencies
-- Use of Dependabot to update commit hashes as necessary
-- Use of OpenSSF's [Security Scorecard](https://github.com/ossf/scorecard) (SCORECARD_TOKEN setup required)
-- Use of Step Security's [Harden Runner](https://github.com/step-security/harden-runner)
-- Codespell
-- Super-Linter
-- Semgrep (SEMGREP_APP_TOKEN setup required)
-- (optional) Sync to GitLab (GITLAB_TOKEN setup required)
+**Please note:** Server availability and accuracy can vary. Always verify servers before relying on them for critical applications. Contributions and updates to the list are welcome via pull requests to the `ntp-sources.yml` file.
+
+## The List
+|Hostname|AS|Stratum|Location|Owner|Notes|
+|---|---|:---:|---|---|---|
+|time.google.com|AS15169|2|Google Public NTP|Google|Anycast|
+|time1.google.com|AS15169|2|Google Public NTP|Google||
+|time2.google.com|AS15169|2|Google Public NTP|Google||
+|time3.google.com|AS15169|2|Google Public NTP|Google||
+|time4.google.com|AS15169|2|Google Public NTP|Google||
+|time.android.com|AS15169|2|Google Public NTP|Google|Anycast|
+||
+|time.aws.com|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon|Anycast|
+|amazon.pool.ntp.org|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon||
+|0.amazon.pool.ntp.org|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon||
+|1.amazon.pool.ntp.org|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon||
+|2.amazon.pool.ntp.org|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon||
+|3.amazon.pool.ntp.org|AS16509, AS14618, AS399991|2|public Amazon Time Sync Service|Amazon||
+||
+|time.cloudflare.com|AS13335|2|Cloudflare NTP|Cloudflare|Anycast|
+||
+|time.facebook.com|AS32934|2|Facebook NTP|Facebook|Anycast|
+|time1.facebook.com|AS32934|2|Facebook NTP|Facebook||
+|time2.facebook.com|AS32934|2|Facebook NTP|Facebook||
+|time3.facebook.com|AS32934|2|Facebook NTP|Facebook||
+|time4.facebook.com|AS32934|2|Facebook NTP|Facebook||
+|time5.facebook.com|AS32934|2|Facebook NTP|Facebook||
+||
+|time.windows.com|AS8075|2|Microsoft NTP server|Microsoft|Anycast|
+||
+|time.apple.com|AS714, AS6185|2|Apple NTP server|Apple|Anycast|
+|time-macos.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time-ios.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time1.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time2.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time3.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time4.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time5.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time6.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time7.apple.com|AS714, AS6185|2|Apple NTP server|Apple||
+|time.euro.apple.com|AS714, AS6185|2|Apple NTP server|Apple|Europe region|
+|time.asia.apple.com|AS714, AS6185|2|Apple NTP server|Apple|Asia region, From comments|
+||
+|clepsydra.dec.com|Unknown|Unknown|DEC/Compaq/HP|HP||
+|clepsydra.labs.hp.com|Unknown|Unknown|DEC/Compaq/HP|HP||
+|clepsydra.hpl.hp.com|Unknown|Unknown|DEC/Compaq/HP|HP||
+|usno.labs.hp.com|Unknown|Unknown|DEC/Compaq/HP|HP||
+||
+|time-a-g.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-b-g.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-c-g.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-d-g.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-a-wwv.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-b-wwv.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-c-wwv.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-d-wwv.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-a-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-b-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-c-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-d-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST|Anycast|
+|time-e-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-e-g.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-e-wwv.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-nw.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-a.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|time-b.nist.gov|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST||
+|utcnist.colorado.edu|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST|Operated by University of Colorado for NIST|
+|utcnist2.colorado.edu|AS49, AS104|1|NIST Internet Time Service (ITS)|NIST|Operated by University of Colorado for NIST|
+||
+|ntp1.vniiftri.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp2.vniiftri.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp3.vniiftri.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp4.vniiftri.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp.sstf.nsk.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp1.niiftri.irkutsk.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp2.niiftri.irkutsk.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|vniiftri.khv.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|vniiftri2.khv.ru|Unknown|1|VNIIFTRI|VNIIFTRI|Stratum 1|
+|ntp21.vniiftri.ru|Unknown|2|VNIIFTRI|VNIIFTRI|Stratum 2|
+||
+|ntp.mobatime.ru|Unknown|1|Mobatime|Mobatime|Stratum 1|
+||
+|ntp0.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp1.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp2.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp3.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp4.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp5.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp6.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+|ntp7.ntp-servers.net|Unknown|Unknown|NTP SERVERS|ntp-servers.net||
+||
+|ntp1.stratum1.ru|Unknown|1|Stratum 1 Russia|stratum1.ru|Stratum 1|
+|ntp2.stratum1.ru|Unknown|1|Stratum 1 Russia|stratum1.ru|Stratum 1|
+|ntp3.stratum1.ru|Unknown|1|Stratum 1 Russia|stratum1.ru|Stratum 1|
+|ntp4.stratum1.ru|Unknown|1|Stratum 1 Russia|stratum1.ru|Stratum 1|
+|ntp5.stratum1.ru|Unknown|1|Stratum 1 Russia|stratum1.ru|Stratum 1|
+||
+|ntp1.stratum2.ru|Unknown|2|Stratum 2 Russia|stratum2.ru|Stratum 2, Москва|
+|ntp2.stratum2.ru|Unknown|2|Stratum 2 Russia|stratum2.ru|Stratum 2|
+|ntp3.stratum2.ru|Unknown|2|Stratum 2 Russia|stratum2.ru|Stratum 2|
+|ntp4.stratum2.ru|Unknown|2|Stratum 2 Russia|stratum2.ru|Stratum 2|
+|ntp5.stratum2.ru|Unknown|2|Stratum 2 Russia|stratum2.ru|Stratum 2|
+||
+|stratum1.net|Unknown|1|stratum1.net|stratum1.net|Stratum 1|
+||
+|ntp.time.in.ua|Unknown|1|time.in.ua|time.in.ua|Stratum 1|
+|ntp2.time.in.ua|Unknown|1|time.in.ua|time.in.ua|Stratum 1|
+|ntp3.time.in.ua|Unknown|2|time.in.ua|time.in.ua|Stratum 2|
+||
+|ntp.ru|AS8915|Unknown|Company Delfa Co. Ltd.|Company Delfa Co. Ltd.||
+||
+|ts1.aco.net|AS1853|Unknown|ACO.net|ACO.net||
+|ts2.aco.net|AS1853|Unknown|ACO.net|ACO.net||
+||
+|ntp1.net.berkeley.edu|AS25|1|Berkeley|University of California, Berkeley|Stratum 1|
+|ntp2.net.berkeley.edu|AS25|1|Berkeley|University of California, Berkeley|Stratum 1|
+||
+|ntp.gsu.edu|AS10631|Unknown|Georgia State University|Georgia State University||
+||
+|tick.usask.ca|AS22950|Unknown|University of Saskatchewan|University of Saskatchewan||
+|tock.usask.ca|AS22950|Unknown|University of Saskatchewan|University of Saskatchewan||
+||
+|ntp.nsu.ru|AS3335|2|NSU|Novosibirsk State University|Stratum 2|
+||
+|ntp.psn.ru|AS41783|Unknown|ITAEC|ITAEC||
+||
+|ntp.rsu.edu.ru|AS47124|1|RSU|Rostov State University|Stratum 1|
+||
+|ntp.nict.jp|AS9355|1|National Institute of Information and Communications Technology|NICT||
+||
+|ntp1.jst.mfeed.ad.jp|AS7521|1|INTERNET MULTIFEED CO.|INTERNET MULTIFEED CO.||
+|ntp2.jst.mfeed.ad.jp|AS7521|1|INTERNET MULTIFEED CO.|INTERNET MULTIFEED CO.||
+|ntp3.jst.mfeed.ad.jp|AS7521|1|INTERNET MULTIFEED CO.|INTERNET MULTIFEED CO.||
+||
+|x.ns.gin.ntt.net|AS2914|Unknown|NTT|NTT||
+|y.ns.gin.ntt.net|AS2914|Unknown|NTT|NTT||
+||
+|clock.sjc.he.net|AS6939|1|HE.net Public Stratum 1 NTP servers|HE.net|San Jose, CA|
+|clock.fmt.he.net|AS6939|1|HE.net Public Stratum 1 NTP servers|HE.net|Fremont, CA|
+|clock.nyc.he.net|AS6939|1|HE.net Public Stratum 1 NTP servers|HE.net|New York City, NY|
+||
+|ntp.fiord.ru|AS28917|Unknown|TRC Fiord|TRC Fiord||
+||
+|gbg1.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Göteborg|
+|gbg2.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Göteborg|
+|mmo1.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Malmö|
+|mmo2.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Malmö|
+|sth1.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Stockholm|
+|sth2.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Stockholm|
+|svl1.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Sundsvall|
+|svl2.ntp.se|AS57021|1|Netnod NTP service|Netnod|Stratum 1, Sundsvall|
+|ntp.se|AS57021|1|Netnod NTP service|Netnod|Anycast address for nearest NTP server|
+||
+|ntp.qix.ca|AS14086|Unknown|QiX NTP|QiX||
+|ntp1.qix.ca|AS14086|Unknown|QiX NTP|QiX||
+|ntp2.qix.ca|AS14086|Unknown|QiX NTP|QiX||
+||
+|ntp.yycix.ca|AS396515|Unknown|YYCIX NTP|YYCIX||
+||
+|ntp.ix.ru|AS43832|1|MSK-IX NTP|MSK-IX|Stratum 1|
+||
+|ntp1.hetzner.de|AS24940|2|Hetzner Online|Hetzner Online||
+|ntp2.hetzner.de|AS24940|2|Hetzner Online|Hetzner Online||
+|ntp3.hetzner.de|AS24940|2|Hetzner Online|Hetzner Online||
+||
+|time-a.as43289.net|AS43289|Unknown|Trabia-Network|Trabia-Network||
+|time-b.as43289.net|AS43289|Unknown|Trabia-Network|Trabia-Network||
+|time-c.as43289.net|AS43289|Unknown|Trabia-Network|Trabia-Network||
+||
+|ntp.ripe.net|AS3333|2|RIPE|RIPE NCC||
+||
+|clock.isc.org|AS1280|1|Internet Systems Consortium|ISC|prev ntp.isc.org|
+||
+|ntp.time.nl|AS1140|1|TimeNL/SIDN Labs|SIDN Labs|ntp1.time.nl|
+|ntppool1.time.nl|AS1140|1|TimeNL/SIDN Labs|SIDN Labs|Preferred, From comments|
+|ntppool2.time.nl|AS1140|1|TimeNL/SIDN Labs|SIDN Labs|Preferred, From comments|
+||
+|ntp0.as34288.net|AS34288|Unknown|Kantonsschule Zug|Kantonsschule Zug||
+|ntp1.as34288.net|AS34288|Unknown|Kantonsschule Zug|Kantonsschule Zug||
+||
+|ntp.ntsc.ac.cn|AS4808, AS9808, AS23724|1|Chinese Academy of Sciences Nation Time Service Center|Chinese Academy of Sciences||
+||
+|ntp.nat.ms|AS30746|1|Nat Morris|Nat Morris|Stratum 1|
+||
+|tick.usno.navy.mil|AS747|1|US Naval Observatory|US Navy||
+|tock.usno.navy.mil|AS747|1|US Naval Observatory|US Navy||
+|ntp2.usno.navy.mil|AS747|1|US Naval Observatory|US Navy||
+||
+|timekeeper.isi.edu|AS2702|Unknown|ISI|Information Sciences Institute||
+||
+|rackety.udel.edu|AS300|Unknown|University of Delaware|University of Delaware||
+|mizbeaver.udel.edu|AS300|Unknown|University of Delaware|University of Delaware||
+||
+|otc1.psu.edu|AS38|Unknown|Pennsylvania State University|Pennsylvania State University||
+||
+|gnomon.cc.columbia.edu|AS117|Unknown|Columbia University|Columbia University||
+||
+|navobs1.gatech.edu|AS2637|Unknown|Georgia Institute of Technology|Georgia Institute of Technology||
+||
+|navobs1.wustl.edu|AS288|Unknown|Washington University in St. Louis|Washington University in St. Louis||
+||
+|now.okstate.edu|AS111|Unknown|Oklahoma State University|Oklahoma State University||
+||
+|ntp.colby.edu|AS10566|Unknown|Colby College|Colby College||
+||
+|ntp-s1.cise.ufl.edu|AS5730|Unknown|University of Florida|University of Florida||
+||
+|bonehed.lcs.mit.edu|AS3|Unknown|MIT LCS|MIT||
+||
+|level1e.cs.unc.edu|AS2807|Unknown|University of North Carolina at Chapel Hill|University of North Carolina at Chapel Hill||
+||
+|tick.ucla.edu|AS52|Unknown|University of California, Los Angeles|University of California, Los Angeles||
+||
+|tick.uh.edu|AS638|Unknown|University of Hawaii|University of Hawaii||
+||
+|ntpstm.netbone-digital.com|Unknown|Unknown|NetBone Digital|NetBone Digital||
+||
+|nist1.symmetricom.com|AS3608|1|Microsemi/Symmetricom|Microsemi||
+||
+|ntp.quintex.com|Unknown|Unknown|Quintex|Quintex||
+||
+|ntp1.conectiv.com|AS16069|Unknown|Conectiv|Conectiv||
+||
+|tock.usshc.com|Unknown|Unknown|USSHC|USSHC||
+||
+|t2.timegps.net|Unknown|Unknown|timegps.net|timegps.net||
+||
+|gps.layer42.net|AS11491|Unknown|Layer42|Layer42||
+||
+|ntp-ca.stygium.net|AS3978|Unknown|Stygium|Stygium||
+||
+|sesku.planeacion.net|Unknown|Unknown|planeacion.net|planeacion.net||
+||
+|ntp0.nl.uu.net|AS8283|Unknown|KPN International Carrier|KPN International Carrier||
+|ntp1.nl.uu.net|AS8283|Unknown|KPN International Carrier|KPN International Carrier||
+||
+|navobs1.oar.net|Unknown|Unknown|oar.net|oar.net||
+||
+|ntp-galway.hea.net|AS1213|Unknown|HEAnet|HEAnet|Galway|
+||
+|ntp1.ona.org|Unknown|Unknown|ona.org|ona.org||
+||
+|ntp.your.org|Unknown|Unknown|your.org|your.org||
+||
+|ntp.mrow.org|Unknown|Unknown|mrow.org|mrow.org||
+||
+|time.fu-berlin.de|AS680|Unknown|Germany|Freie Universitaet Berlin||
+|ntps1-0.cs.tu-berlin.de|AS680|Unknown|Germany|Technische Universitaet Berlin||
+|ntps1-1.cs.tu-berlin.de|AS680|Unknown|Germany|Technische Universitaet Berlin||
+|ntps1-0.uni-erlangen.de|AS680|Unknown|Germany|University of Erlangen-Nuremberg||
+|ntps1-1.uni-erlangen.de|AS680|Unknown|Germany|University of Erlangen-Nuremberg||
+|ntp1.fau.de|AS680|Unknown|Germany|University of Erlangen-Nuremberg (FAU)|From .de comments|
+|ntp2.fau.de|AS680|Unknown|Germany|University of Erlangen-Nuremberg (FAU)|From .de comments|
+|ntp.dianacht.de|Unknown|Unknown|Germany|dianacht.de||
+|zeit.fu-berlin.de|AS680|Unknown|Germany|Freie Universitaet Berlin||
+|ptbtime1.ptb.de|AS1896|1|Germany|PTB||
+|ptbtime2.ptb.de|AS1896|1|Germany|PTB||
+|rustime01.rus.uni-stuttgart.de|AS680|Unknown|Germany|University of Stuttgart||
+|rustime02.rus.uni-stuttgart.de|AS680|Unknown|Germany|University of Stuttgart||
+||
+|chime1.surfnet.nl|AS1103|Unknown|Netherlands|SURFnet||
+|ntp.vsl.nl|AS34929|1|Netherlands|VSL||
+||
+|asynchronos.iiss.at|AS8401|Unknown|Austria|ACOnet / University of Vienna||
+||
+|ntp.nic.cz|AS25204|2|Czech Republic|CZ.NIC||
+|time.ufe.cz|AS25192|1|Czech Republic|UFE CAS||
+||
+|ntp.fizyka.umk.pl|AS8805|Unknown|Poland|Nicolaus Copernicus University||
+|tempus1.gum.gov.pl|AS43900|1|Poland|GUM||
+|tempus2.gum.gov.pl|AS43900|1|Poland|GUM||
+||
+|ntp1.usv.ro|AS8713|Unknown|Romania|University Stefan cel Mare Suceava||
+|ntp3.usv.ro|AS8713|Unknown|Romania|University Stefan cel Mare Suceava||
+||
+|timehost.lysator.liu.se|AS1653|Unknown|Sweden|Academic Computer Club Lysator||
+|time1.stupi.se|Unknown|Unknown|Sweden|stupi.se||
+||
+|time.nrc.ca|AS573|1|Canada|National Research Council Canada||
+|clock.uregina.ca|AS641|Unknown|Canada|University of Regina||
+||
+|cronos.cenam.mx|AS8017|1|Mexico|CENAM||
+|ntp.lcf.mx|Unknown|Unknown|Mexico|lcf.mx||
+||
+|hora.roa.es|AS31007|1|Spain|ROA||
+|minuto.roa.es|AS31007|1|Spain|ROA||
+||
+|ntp1.inrim.it|AS29109|1|Italy|INRIM||
+|ntp2.inrim.it|AS29109|1|Italy|INRIM||
+||
+|ntp1.oma.be|AS5400|1|Belgium|Royal Observatory of Belgium||
+|ntp2.oma.be|AS5400|1|Belgium|Royal Observatory of Belgium||
+||
+|ntp.atomki.mta.hu|AS197038|2|Hungary|ATOMKI||
+||
+|ntp.i2t.ehu.eus|AS2110|Unknown|Basque Country|University of the Basque Country (EHU)||
+||
+|ntp.neel.ch|AS34569|Unknown|Switzerland|Neel Engineering||
+||
+|ntp.neu.edu.cn|AS4538|Unknown|China|Northeastern University||
+||
+|ntps1.pads.ufrj.br|AS1553|Unknown|Brazil|Federal University of Rio de Janeiro||
+||
+|ntp.shoa.cl|AS16299|1|Chile|Hydrographic and Oceanographic Service of the Chilean Navy||
+||
+|time.esa.int|AS15559|Unknown|International|European Space Agency||
+|time1.esa.int|AS15559|Unknown|International|European Space Agency||
+||
+|ntp.day.ir|AS42337|Unknown|Iran|Day ICT|From comments|
+||
+|ntp.ubuntu.com|AS201815|2|Ubuntu|Canonical|From comments, Anycast|
+||
+|ntp.viarouge.net|AS207288|Unknown|France|Hubert Viarouge|From comments|
+||
+|ntp1.dmz.terryburton.co.uk|Unknown|Unknown|UK|Terry Burton|From comments|
+|ntp2.dmz.terryburton.co.uk|Unknown|Unknown|UK|Terry Burton|From comments|
+||
+|time1.ntp.hr|AS49932|Unknown|Croatia|CARNET|From comments|
+|time2.ntp.hr|AS49932|Unknown|Croatia|CARNET|From comments|
+|os.ntp.carnet.hr|AS49932|2|Croatia|CARNET|From comments, Stratum 2|
+|ri.ntp.carnet.hr|AS49932|2|Croatia|CARNET|From comments, Stratum 2|
+|st.ntp.carnet.hr|AS49932|2|Croatia|CARNET|From comments, Stratum 2|
+|zg1.ntp.carnet.hr|AS49932|2|Croatia|CARNET|From comments, Stratum 2|
+|zg2.ntp.carnet.hr|AS49932|2|Croatia|CARNET|From comments, Stratum 2|
+||
+|stdtime.gov.hk|AS4780|1|Hong Kong|Hong Kong Observatory|From comments|
+||
+|ntp5.leontp.com|Unknown|Unknown|UK|Leo Bodnar|From comments|
+|ntp6.leontp.com|Unknown|Unknown|UK|Leo Bodnar|From comments|
+|ntp7.leontp.com|Unknown|Unknown|UK|Leo Bodnar|From comments|
+|ntp8.leontp.com|Unknown|Unknown|UK|Leo Bodnar|From comments|
+|ntp9.leontp.com|Unknown|Unknown|UK|Leo Bodnar|From comments|
+|timekeeper.webwiz.net|AS44929|Unknown|UK|Web Wiz|From comments|
+|ntp.theitman.uk|Unknown|Unknown|UK|TheITMan|From comments|
+|eshail.batc.org.uk|Unknown|Unknown|UK|BATC|From comments|
+||
+|ntp.heppen.be|Unknown|Unknown|Belgium|ON5HB Ham-radio users|From comments|
+||
+|time.xtracloud.net|AS174|Unknown|Qualcomm|Qualcomm|From comments|
+
+## Star History
+<!-- Placeholder for potential future Star History graph or section -->

--- a/chrony.conf
+++ b/chrony.conf
@@ -1,0 +1,436 @@
+#
+# NTS servers in chrony format - Modified to standard NTP
+#
+
+# Google Public NTP
+server time.google.com iburst
+server time1.google.com iburst
+server time2.google.com iburst
+server time3.google.com iburst
+server time4.google.com iburst
+server time.android.com iburst
+
+# public Amazon Time Sync Service
+server time.aws.com iburst
+server amazon.pool.ntp.org iburst
+server 0.amazon.pool.ntp.org iburst
+server 1.amazon.pool.ntp.org iburst
+server 2.amazon.pool.ntp.org iburst
+server 3.amazon.pool.ntp.org iburst
+
+# Cloudflare NTP
+server time.cloudflare.com iburst
+
+# Facebook NTP
+server time.facebook.com iburst
+server time1.facebook.com iburst
+server time2.facebook.com iburst
+server time3.facebook.com iburst
+server time4.facebook.com iburst
+server time5.facebook.com iburst
+
+# Microsoft NTP server
+server time.windows.com iburst
+
+# Apple NTP server
+server time.apple.com iburst
+server time-macos.apple.com iburst
+server time-ios.apple.com iburst
+server time1.apple.com iburst
+server time2.apple.com iburst
+server time3.apple.com iburst
+server time4.apple.com iburst
+server time5.apple.com iburst
+server time6.apple.com iburst
+server time7.apple.com iburst
+server time.euro.apple.com iburst
+server time.asia.apple.com iburst
+
+# DEC/Compaq/HP
+server clepsydra.dec.com iburst
+server clepsydra.labs.hp.com iburst
+server clepsydra.hpl.hp.com iburst
+server usno.labs.hp.com iburst
+
+# NIST Internet Time Service (ITS)
+server time-a-g.nist.gov iburst
+server time-b-g.nist.gov iburst
+server time-c-g.nist.gov iburst
+server time-d-g.nist.gov iburst
+server time-a-wwv.nist.gov iburst
+server time-b-wwv.nist.gov iburst
+server time-c-wwv.nist.gov iburst
+server time-d-wwv.nist.gov iburst
+server time-a-b.nist.gov iburst
+server time-b-b.nist.gov iburst
+server time-c-b.nist.gov iburst
+server time-d-b.nist.gov iburst
+server time.nist.gov iburst
+server time-e-b.nist.gov iburst
+server time-e-g.nist.gov iburst
+server time-e-wwv.nist.gov iburst
+server time-nw.nist.gov iburst
+server time-a.nist.gov iburst
+server time-b.nist.gov iburst
+server utcnist.colorado.edu iburst
+server utcnist2.colorado.edu iburst
+
+# VNIIFTRI
+server ntp1.vniiftri.ru iburst
+server ntp2.vniiftri.ru iburst
+server ntp3.vniiftri.ru iburst
+server ntp4.vniiftri.ru iburst
+server ntp.sstf.nsk.ru iburst
+server ntp1.niiftri.irkutsk.ru iburst
+server ntp2.niiftri.irkutsk.ru iburst
+server vniiftri.khv.ru iburst
+server vniiftri2.khv.ru iburst
+server ntp21.vniiftri.ru iburst
+
+# Mobatime
+server ntp.mobatime.ru iburst
+
+# NTP SERVERS
+server ntp0.ntp-servers.net iburst
+server ntp1.ntp-servers.net iburst
+server ntp2.ntp-servers.net iburst
+server ntp3.ntp-servers.net iburst
+server ntp4.ntp-servers.net iburst
+server ntp5.ntp-servers.net iburst
+server ntp6.ntp-servers.net iburst
+server ntp7.ntp-servers.net iburst
+
+# Stratum 1 Russia
+server ntp1.stratum1.ru iburst
+server ntp2.stratum1.ru iburst
+server ntp3.stratum1.ru iburst
+server ntp4.stratum1.ru iburst
+server ntp5.stratum1.ru iburst
+
+# Stratum 2 Russia
+server ntp1.stratum2.ru iburst
+server ntp2.stratum2.ru iburst
+server ntp3.stratum2.ru iburst
+server ntp4.stratum2.ru iburst
+server ntp5.stratum2.ru iburst
+
+# stratum1.net
+server stratum1.net iburst
+
+# time.in.ua
+server ntp.time.in.ua iburst
+server ntp2.time.in.ua iburst
+server ntp3.time.in.ua iburst
+
+# Company Delfa Co. Ltd.
+server ntp.ru iburst
+
+# ACO.net
+server ts1.aco.net iburst
+server ts2.aco.net iburst
+
+# Berkeley
+server ntp1.net.berkeley.edu iburst
+server ntp2.net.berkeley.edu iburst
+
+# Georgia State University
+server ntp.gsu.edu iburst
+
+# University of Saskatchewan
+server tick.usask.ca iburst
+server tock.usask.ca iburst
+
+# NSU
+server ntp.nsu.ru iburst
+
+# ITAEC
+server ntp.psn.ru iburst
+
+# RSU
+server ntp.rsu.edu.ru iburst
+
+# National Institute of Information and Communications Technology
+server ntp.nict.jp iburst
+
+# INTERNET MULTIFEED CO.
+server ntp1.jst.mfeed.ad.jp iburst
+server ntp2.jst.mfeed.ad.jp iburst
+server ntp3.jst.mfeed.ad.jp iburst
+
+# NTT
+server x.ns.gin.ntt.net iburst
+server y.ns.gin.ntt.net iburst
+
+# HE.net Public Stratum 1 NTP servers
+server clock.sjc.he.net iburst
+server clock.fmt.he.net iburst
+server clock.nyc.he.net iburst
+
+# TRC Fiord
+server ntp.fiord.ru iburst
+
+# Netnod NTP service
+server gbg1.ntp.se iburst
+server gbg2.ntp.se iburst
+server mmo1.ntp.se iburst
+server mmo2.ntp.se iburst
+server sth1.ntp.se iburst
+server sth2.ntp.se iburst
+server svl1.ntp.se iburst
+server svl2.ntp.se iburst
+server ntp.se iburst
+
+# QiX NTP
+server ntp.qix.ca iburst
+server ntp1.qix.ca iburst
+server ntp2.qix.ca iburst
+
+# YYCIX NTP
+server ntp.yycix.ca iburst
+
+# MSK-IX NTP
+server ntp.ix.ru iburst
+
+# Hetzner Online
+server ntp1.hetzner.de iburst
+server ntp2.hetzner.de iburst
+server ntp3.hetzner.de iburst
+
+# Trabia-Network
+server time-a.as43289.net iburst
+server time-b.as43289.net iburst
+server time-c.as43289.net iburst
+
+# RIPE
+server ntp.ripe.net iburst
+
+# Internet Systems Consortium
+server clock.isc.org iburst
+
+# TimeNL/SIDN Labs
+server ntp.time.nl iburst
+server ntppool1.time.nl iburst
+server ntppool2.time.nl iburst
+
+# Kantonsschule Zug
+server ntp0.as34288.net iburst
+server ntp1.as34288.net iburst
+
+# Chinese Academy of Sciences Nation Time Service Center
+server ntp.ntsc.ac.cn iburst
+
+# Nat Morris
+server ntp.nat.ms iburst
+
+# US Naval Observatory
+server tick.usno.navy.mil iburst
+server tock.usno.navy.mil iburst
+server ntp2.usno.navy.mil iburst
+
+# ISI
+server timekeeper.isi.edu iburst
+
+# University of Delaware
+server rackety.udel.edu iburst
+server mizbeaver.udel.edu iburst
+
+# Pennsylvania State University
+server otc1.psu.edu iburst
+
+# Columbia University
+server gnomon.cc.columbia.edu iburst
+
+# Georgia Institute of Technology
+server navobs1.gatech.edu iburst
+
+# Washington University in St. Louis
+server navobs1.wustl.edu iburst
+
+# Oklahoma State University
+server now.okstate.edu iburst
+
+# Colby College
+server ntp.colby.edu iburst
+
+# University of Florida
+server ntp-s1.cise.ufl.edu iburst
+
+# MIT LCS
+server bonehed.lcs.mit.edu iburst
+
+# University of North Carolina at Chapel Hill
+server level1e.cs.unc.edu iburst
+
+# University of California, Los Angeles
+server tick.ucla.edu iburst
+
+# University of Hawaii
+server tick.uh.edu iburst
+
+# NetBone Digital
+server ntpstm.netbone-digital.com iburst
+
+# Microsemi/Symmetricom
+server nist1.symmetricom.com iburst
+
+# Quintex
+server ntp.quintex.com iburst
+
+# Conectiv
+server ntp1.conectiv.com iburst
+
+# USSHC
+server tock.usshc.com iburst
+
+# timegps.net
+server t2.timegps.net iburst
+
+# Layer42
+server gps.layer42.net iburst
+
+# Stygium
+server ntp-ca.stygium.net iburst
+
+# planeacion.net
+server sesku.planeacion.net iburst
+
+# KPN International Carrier
+server ntp0.nl.uu.net iburst
+server ntp1.nl.uu.net iburst
+
+# oar.net
+server navobs1.oar.net iburst
+
+# HEAnet
+server ntp-galway.hea.net iburst
+
+# ona.org
+server ntp1.ona.org iburst
+
+# your.org
+server ntp.your.org iburst
+
+# mrow.org
+server ntp.mrow.org iburst
+
+# Germany
+server time.fu-berlin.de iburst
+server ntps1-0.cs.tu-berlin.de iburst
+server ntps1-1.cs.tu-berlin.de iburst
+server ntps1-0.uni-erlangen.de iburst
+server ntps1-1.uni-erlangen.de iburst
+server ntp1.fau.de iburst
+server ntp2.fau.de iburst
+server ntp.dianacht.de iburst
+server zeit.fu-berlin.de iburst
+server ptbtime1.ptb.de iburst
+server ptbtime2.ptb.de iburst
+server rustime01.rus.uni-stuttgart.de iburst
+server rustime02.rus.uni-stuttgart.de iburst
+
+# Netherlands
+server chime1.surfnet.nl iburst
+server ntp.vsl.nl iburst
+
+# Austria
+server asynchronos.iiss.at iburst
+
+# Czech Republic
+server ntp.nic.cz iburst
+server time.ufe.cz iburst
+
+# Poland
+server ntp.fizyka.umk.pl iburst
+server tempus1.gum.gov.pl iburst
+server tempus2.gum.gov.pl iburst
+
+# Romania
+server ntp1.usv.ro iburst
+server ntp3.usv.ro iburst
+
+# Sweden
+server timehost.lysator.liu.se iburst
+server time1.stupi.se iburst
+
+# Canada
+server time.nrc.ca iburst
+server clock.uregina.ca iburst
+
+# Mexico
+server cronos.cenam.mx iburst
+server ntp.lcf.mx iburst
+
+# Spain
+server hora.roa.es iburst
+server minuto.roa.es iburst
+
+# Italy
+server ntp1.inrim.it iburst
+server ntp2.inrim.it iburst
+
+# Belgium
+server ntp1.oma.be iburst
+server ntp2.oma.be iburst
+
+# Hungary
+server ntp.atomki.mta.hu iburst
+
+# Basque Country
+server ntp.i2t.ehu.eus iburst
+
+# Switzerland
+server ntp.neel.ch iburst
+
+# China
+server ntp.neu.edu.cn iburst
+
+# Brazil
+server ntps1.pads.ufrj.br iburst
+
+# Chile
+server ntp.shoa.cl iburst
+
+# International
+server time.esa.int iburst
+server time1.esa.int iburst
+
+# Iran
+server ntp.day.ir iburst
+
+# Ubuntu
+server ntp.ubuntu.com iburst
+
+# France
+server ntp.viarouge.net iburst
+
+# UK
+server ntp1.dmz.terryburton.co.uk iburst
+server ntp2.dmz.terryburton.co.uk iburst
+
+# Croatia
+server time1.ntp.hr iburst
+server time2.ntp.hr iburst
+server os.ntp.carnet.hr iburst
+server ri.ntp.carnet.hr iburst
+server st.ntp.carnet.hr iburst
+server zg1.ntp.carnet.hr iburst
+server zg2.ntp.carnet.hr iburst
+
+# Hong Kong
+server stdtime.gov.hk iburst
+
+# UK
+server ntp5.leontp.com iburst
+server ntp6.leontp.com iburst
+server ntp7.leontp.com iburst
+server ntp8.leontp.com iburst
+server ntp9.leontp.com iburst
+server timekeeper.webwiz.net iburst
+server ntp.theitman.uk iburst
+server eshail.batc.org.uk iburst
+
+# Belgium
+server ntp.heppen.be iburst
+
+# Qualcomm
+server time.xtracloud.net iburst

--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -1,0 +1,1674 @@
+servers:
+  - hostname: "time.google.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time1.google.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: ""
+    vm: false
+  - hostname: "time2.google.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: ""
+    vm: false
+  - hostname: "time3.google.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: ""
+    vm: false
+  - hostname: "time4.google.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: ""
+    vm: false
+  - hostname: "time.android.com"
+    AS: "AS15169"
+    stratum: 2
+    location: "Google Public NTP"
+    owner: "Google"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time.aws.com"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: "Anycast"
+    vm: false
+  - hostname: "amazon.pool.ntp.org"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: ""
+    vm: false
+  - hostname: "0.amazon.pool.ntp.org"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: ""
+    vm: false
+  - hostname: "1.amazon.pool.ntp.org"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: ""
+    vm: false
+  - hostname: "2.amazon.pool.ntp.org"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: ""
+    vm: false
+  - hostname: "3.amazon.pool.ntp.org"
+    AS: "AS16509, AS14618, AS399991"
+    stratum: 2
+    location: "public Amazon Time Sync Service"
+    owner: "Amazon"
+    notes: ""
+    vm: false
+  - hostname: "time.cloudflare.com"
+    AS: "AS13335"
+    stratum: 2
+    location: "Cloudflare NTP"
+    owner: "Cloudflare"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time1.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: ""
+    vm: false
+  - hostname: "time2.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: ""
+    vm: false
+  - hostname: "time3.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: ""
+    vm: false
+  - hostname: "time4.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: ""
+    vm: false
+  - hostname: "time5.facebook.com"
+    AS: "AS32934"
+    stratum: 2
+    location: "Facebook NTP"
+    owner: "Facebook"
+    notes: ""
+    vm: false
+  - hostname: "time.windows.com"
+    AS: "AS8075"
+    stratum: 2
+    location: "Microsoft NTP server"
+    owner: "Microsoft"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time-macos.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time-ios.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time1.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time2.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time3.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time4.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time5.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time6.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time7.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: ""
+    vm: false
+  - hostname: "time.euro.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: "Europe region"
+    vm: false
+  - hostname: "time.asia.apple.com"
+    AS: "AS714, AS6185"
+    stratum: 2
+    location: "Apple NTP server"
+    owner: "Apple"
+    notes: "Asia region, From comments"
+    vm: false
+  - hostname: "clepsydra.dec.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "DEC/Compaq/HP"
+    owner: "HP"
+    notes: ""
+    vm: false
+  - hostname: "clepsydra.labs.hp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "DEC/Compaq/HP"
+    owner: "HP"
+    notes: ""
+    vm: false
+  - hostname: "clepsydra.hpl.hp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "DEC/Compaq/HP"
+    owner: "HP"
+    notes: ""
+    vm: false
+  - hostname: "usno.labs.hp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "DEC/Compaq/HP"
+    owner: "HP"
+    notes: ""
+    vm: false
+  - hostname: "time-a-g.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-b-g.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-c-g.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-d-g.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-a-wwv.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-b-wwv.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-c-wwv.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-d-wwv.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-a-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-b-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-c-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-d-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: "Anycast"
+    vm: false
+  - hostname: "time-e-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-e-g.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-e-wwv.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-nw.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-a.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "time-b.nist.gov"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: ""
+    vm: false
+  - hostname: "utcnist.colorado.edu"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: "Operated by University of Colorado for NIST"
+    vm: false
+  - hostname: "utcnist2.colorado.edu"
+    AS: "AS49, AS104"
+    stratum: 1
+    location: "NIST Internet Time Service (ITS)"
+    owner: "NIST"
+    notes: "Operated by University of Colorado for NIST"
+    vm: false
+  - hostname: "ntp1.vniiftri.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp2.vniiftri.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp3.vniiftri.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp4.vniiftri.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp.sstf.nsk.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp1.niiftri.irkutsk.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp2.niiftri.irkutsk.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "vniiftri.khv.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "vniiftri2.khv.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp21.vniiftri.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "VNIIFTRI"
+    owner: "VNIIFTRI"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp.mobatime.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Mobatime"
+    owner: "Mobatime"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp0.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp3.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp4.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp5.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp6.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp7.ntp-servers.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NTP SERVERS"
+    owner: "ntp-servers.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.stratum1.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Stratum 1 Russia"
+    owner: "stratum1.ru"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp2.stratum1.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Stratum 1 Russia"
+    owner: "stratum1.ru"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp3.stratum1.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Stratum 1 Russia"
+    owner: "stratum1.ru"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp4.stratum1.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Stratum 1 Russia"
+    owner: "stratum1.ru"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp5.stratum1.ru"
+    AS: "Unknown"
+    stratum: 1
+    location: "Stratum 1 Russia"
+    owner: "stratum1.ru"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp1.stratum2.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "Stratum 2 Russia"
+    owner: "stratum2.ru"
+    notes: "Stratum 2, Москва"
+    vm: false
+  - hostname: "ntp2.stratum2.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "Stratum 2 Russia"
+    owner: "stratum2.ru"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp3.stratum2.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "Stratum 2 Russia"
+    owner: "stratum2.ru"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp4.stratum2.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "Stratum 2 Russia"
+    owner: "stratum2.ru"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp5.stratum2.ru"
+    AS: "Unknown"
+    stratum: 2
+    location: "Stratum 2 Russia"
+    owner: "stratum2.ru"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "stratum1.net"
+    AS: "Unknown"
+    stratum: 1
+    location: "stratum1.net"
+    owner: "stratum1.net"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp.time.in.ua"
+    AS: "Unknown"
+    stratum: 1
+    location: "time.in.ua"
+    owner: "time.in.ua"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp2.time.in.ua"
+    AS: "Unknown"
+    stratum: 1
+    location: "time.in.ua"
+    owner: "time.in.ua"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp3.time.in.ua"
+    AS: "Unknown"
+    stratum: 2
+    location: "time.in.ua"
+    owner: "time.in.ua"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp.ru"
+    AS: "AS8915"
+    stratum: "Unknown"
+    location: "Company Delfa Co. Ltd."
+    owner: "Company Delfa Co. Ltd."
+    notes: ""
+    vm: false
+  - hostname: "ts1.aco.net"
+    AS: "AS1853"
+    stratum: "Unknown"
+    location: "ACO.net"
+    owner: "ACO.net"
+    notes: ""
+    vm: false
+  - hostname: "ts2.aco.net"
+    AS: "AS1853"
+    stratum: "Unknown"
+    location: "ACO.net"
+    owner: "ACO.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.net.berkeley.edu"
+    AS: "AS25"
+    stratum: 1
+    location: "Berkeley"
+    owner: "University of California, Berkeley"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp2.net.berkeley.edu"
+    AS: "AS25"
+    stratum: 1
+    location: "Berkeley"
+    owner: "University of California, Berkeley"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp.gsu.edu"
+    AS: "AS10631"
+    stratum: "Unknown"
+    location: "Georgia State University"
+    owner: "Georgia State University"
+    notes: ""
+    vm: false
+  - hostname: "tick.usask.ca"
+    AS: "AS22950"
+    stratum: "Unknown"
+    location: "University of Saskatchewan"
+    owner: "University of Saskatchewan"
+    notes: ""
+    vm: false
+  - hostname: "tock.usask.ca"
+    AS: "AS22950"
+    stratum: "Unknown"
+    location: "University of Saskatchewan"
+    owner: "University of Saskatchewan"
+    notes: ""
+    vm: false
+  - hostname: "ntp.nsu.ru"
+    AS: "AS3335"
+    stratum: 2
+    location: "NSU"
+    owner: "Novosibirsk State University"
+    notes: "Stratum 2"
+    vm: false
+  - hostname: "ntp.psn.ru"
+    AS: "AS41783"
+    stratum: "Unknown"
+    location: "ITAEC"
+    owner: "ITAEC"
+    notes: ""
+    vm: false
+  - hostname: "ntp.rsu.edu.ru"
+    AS: "AS47124"
+    stratum: 1
+    location: "RSU"
+    owner: "Rostov State University"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp.nict.jp"
+    AS: "AS9355"
+    stratum: 1
+    location: "National Institute of Information and Communications Technology"
+    owner: "NICT"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.jst.mfeed.ad.jp"
+    AS: "AS7521"
+    stratum: 1
+    location: "INTERNET MULTIFEED CO."
+    owner: "INTERNET MULTIFEED CO."
+    notes: ""
+    vm: false
+  - hostname: "ntp2.jst.mfeed.ad.jp"
+    AS: "AS7521"
+    stratum: 1
+    location: "INTERNET MULTIFEED CO."
+    owner: "INTERNET MULTIFEED CO."
+    notes: ""
+    vm: false
+  - hostname: "ntp3.jst.mfeed.ad.jp"
+    AS: "AS7521"
+    stratum: 1
+    location: "INTERNET MULTIFEED CO."
+    owner: "INTERNET MULTIFEED CO."
+    notes: ""
+    vm: false
+  - hostname: "x.ns.gin.ntt.net"
+    AS: "AS2914"
+    stratum: "Unknown"
+    location: "NTT"
+    owner: "NTT"
+    notes: ""
+    vm: false
+  - hostname: "y.ns.gin.ntt.net"
+    AS: "AS2914"
+    stratum: "Unknown"
+    location: "NTT"
+    owner: "NTT"
+    notes: ""
+    vm: false
+  - hostname: "clock.sjc.he.net"
+    AS: "AS6939"
+    stratum: 1
+    location: "HE.net Public Stratum 1 NTP servers"
+    owner: "HE.net"
+    notes: "San Jose, CA"
+    vm: false
+  - hostname: "clock.fmt.he.net"
+    AS: "AS6939"
+    stratum: 1
+    location: "HE.net Public Stratum 1 NTP servers"
+    owner: "HE.net"
+    notes: "Fremont, CA"
+    vm: false
+  - hostname: "clock.nyc.he.net"
+    AS: "AS6939"
+    stratum: 1
+    location: "HE.net Public Stratum 1 NTP servers"
+    owner: "HE.net"
+    notes: "New York City, NY"
+    vm: false
+  - hostname: "ntp.fiord.ru"
+    AS: "AS28917"
+    stratum: "Unknown"
+    location: "TRC Fiord"
+    owner: "TRC Fiord"
+    notes: ""
+    vm: false
+  - hostname: "gbg1.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Göteborg"
+    vm: false
+  - hostname: "gbg2.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Göteborg"
+    vm: false
+  - hostname: "mmo1.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Malmö"
+    vm: false
+  - hostname: "mmo2.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Malmö"
+    vm: false
+  - hostname: "sth1.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Stockholm"
+    vm: false
+  - hostname: "sth2.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Stockholm"
+    vm: false
+  - hostname: "svl1.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Sundsvall"
+    vm: false
+  - hostname: "svl2.ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Stratum 1, Sundsvall"
+    vm: false
+  - hostname: "ntp.se"
+    AS: "AS57021"
+    stratum: 1
+    location: "Netnod NTP service"
+    owner: "Netnod"
+    notes: "Anycast address for nearest NTP server"
+    vm: false
+  - hostname: "ntp.qix.ca"
+    AS: "AS14086"
+    stratum: "Unknown"
+    location: "QiX NTP"
+    owner: "QiX"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.qix.ca"
+    AS: "AS14086"
+    stratum: "Unknown"
+    location: "QiX NTP"
+    owner: "QiX"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.qix.ca"
+    AS: "AS14086"
+    stratum: "Unknown"
+    location: "QiX NTP"
+    owner: "QiX"
+    notes: ""
+    vm: false
+  - hostname: "ntp.yycix.ca"
+    AS: "AS396515"
+    stratum: "Unknown"
+    location: "YYCIX NTP"
+    owner: "YYCIX"
+    notes: ""
+    vm: false
+  - hostname: "ntp.ix.ru"
+    AS: "AS43832"
+    stratum: 1
+    location: "MSK-IX NTP"
+    owner: "MSK-IX"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "ntp1.hetzner.de"
+    AS: "AS24940"
+    stratum: 2
+    location: "Hetzner Online"
+    owner: "Hetzner Online"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.hetzner.de"
+    AS: "AS24940"
+    stratum: 2
+    location: "Hetzner Online"
+    owner: "Hetzner Online"
+    notes: ""
+    vm: false
+  - hostname: "ntp3.hetzner.de"
+    AS: "AS24940"
+    stratum: 2
+    location: "Hetzner Online"
+    owner: "Hetzner Online"
+    notes: ""
+    vm: false
+  - hostname: "time-a.as43289.net"
+    AS: "AS43289"
+    stratum: "Unknown"
+    location: "Trabia-Network"
+    owner: "Trabia-Network"
+    notes: ""
+    vm: false
+  - hostname: "time-b.as43289.net"
+    AS: "AS43289"
+    stratum: "Unknown"
+    location: "Trabia-Network"
+    owner: "Trabia-Network"
+    notes: ""
+    vm: false
+  - hostname: "time-c.as43289.net"
+    AS: "AS43289"
+    stratum: "Unknown"
+    location: "Trabia-Network"
+    owner: "Trabia-Network"
+    notes: ""
+    vm: false
+  - hostname: "ntp.ripe.net"
+    AS: "AS3333"
+    stratum: 2
+    location: "RIPE"
+    owner: "RIPE NCC"
+    notes: ""
+    vm: false
+  - hostname: "clock.isc.org"
+    AS: "AS1280"
+    stratum: 1
+    location: "Internet Systems Consortium"
+    owner: "ISC"
+    notes: "prev ntp.isc.org"
+    vm: false
+  - hostname: "ntp.time.nl"
+    AS: "AS1140"
+    stratum: 1
+    location: "TimeNL/SIDN Labs"
+    owner: "SIDN Labs"
+    notes: "ntp1.time.nl"
+    vm: false
+  - hostname: "ntppool1.time.nl"
+    AS: "AS1140"
+    stratum: 1
+    location: "TimeNL/SIDN Labs"
+    owner: "SIDN Labs"
+    notes: "Preferred, From comments"
+    vm: false
+  - hostname: "ntppool2.time.nl"
+    AS: "AS1140"
+    stratum: 1
+    location: "TimeNL/SIDN Labs"
+    owner: "SIDN Labs"
+    notes: "Preferred, From comments"
+    vm: false
+  - hostname: "ntp0.as34288.net"
+    AS: "AS34288"
+    stratum: "Unknown"
+    location: "Kantonsschule Zug"
+    owner: "Kantonsschule Zug"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.as34288.net"
+    AS: "AS34288"
+    stratum: "Unknown"
+    location: "Kantonsschule Zug"
+    owner: "Kantonsschule Zug"
+    notes: ""
+    vm: false
+  - hostname: "ntp.ntsc.ac.cn"
+    AS: "AS4808, AS9808, AS23724"
+    stratum: 1
+    location: "Chinese Academy of Sciences Nation Time Service Center"
+    owner: "Chinese Academy of Sciences"
+    notes: ""
+    vm: false
+  - hostname: "ntp.nat.ms"
+    AS: "AS30746"
+    stratum: 1
+    location: "Nat Morris"
+    owner: "Nat Morris"
+    notes: "Stratum 1"
+    vm: false
+  - hostname: "tick.usno.navy.mil"
+    AS: "AS747"
+    stratum: 1
+    location: "US Naval Observatory"
+    owner: "US Navy"
+    notes: ""
+    vm: false
+  - hostname: "tock.usno.navy.mil"
+    AS: "AS747"
+    stratum: 1
+    location: "US Naval Observatory"
+    owner: "US Navy"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.usno.navy.mil"
+    AS: "AS747"
+    stratum: 1
+    location: "US Naval Observatory"
+    owner: "US Navy"
+    notes: ""
+    vm: false
+  - hostname: "timekeeper.isi.edu"
+    AS: "AS2702"
+    stratum: "Unknown"
+    location: "ISI"
+    owner: "Information Sciences Institute"
+    notes: ""
+    vm: false
+  - hostname: "rackety.udel.edu"
+    AS: "AS300"
+    stratum: "Unknown"
+    location: "University of Delaware"
+    owner: "University of Delaware"
+    notes: ""
+    vm: false
+  - hostname: "mizbeaver.udel.edu"
+    AS: "AS300"
+    stratum: "Unknown"
+    location: "University of Delaware"
+    owner: "University of Delaware"
+    notes: ""
+    vm: false
+  - hostname: "otc1.psu.edu"
+    AS: "AS38"
+    stratum: "Unknown"
+    location: "Pennsylvania State University"
+    owner: "Pennsylvania State University"
+    notes: ""
+    vm: false
+  - hostname: "gnomon.cc.columbia.edu"
+    AS: "AS117"
+    stratum: "Unknown"
+    location: "Columbia University"
+    owner: "Columbia University"
+    notes: ""
+    vm: false
+  - hostname: "navobs1.gatech.edu"
+    AS: "AS2637"
+    stratum: "Unknown"
+    location: "Georgia Institute of Technology"
+    owner: "Georgia Institute of Technology"
+    notes: ""
+    vm: false
+  - hostname: "navobs1.wustl.edu"
+    AS: "AS288"
+    stratum: "Unknown"
+    location: "Washington University in St. Louis"
+    owner: "Washington University in St. Louis"
+    notes: ""
+    vm: false
+  - hostname: "now.okstate.edu"
+    AS: "AS111"
+    stratum: "Unknown"
+    location: "Oklahoma State University"
+    owner: "Oklahoma State University"
+    notes: ""
+    vm: false
+  - hostname: "ntp.colby.edu"
+    AS: "AS10566"
+    stratum: "Unknown"
+    location: "Colby College"
+    owner: "Colby College"
+    notes: ""
+    vm: false
+  - hostname: "ntp-s1.cise.ufl.edu"
+    AS: "AS5730"
+    stratum: "Unknown"
+    location: "University of Florida"
+    owner: "University of Florida"
+    notes: ""
+    vm: false
+  - hostname: "bonehed.lcs.mit.edu"
+    AS: "AS3"
+    stratum: "Unknown"
+    location: "MIT LCS"
+    owner: "MIT"
+    notes: ""
+    vm: false
+  - hostname: "level1e.cs.unc.edu"
+    AS: "AS2807"
+    stratum: "Unknown"
+    location: "University of North Carolina at Chapel Hill"
+    owner: "University of North Carolina at Chapel Hill"
+    notes: ""
+    vm: false
+  - hostname: "tick.ucla.edu"
+    AS: "AS52"
+    stratum: "Unknown"
+    location: "University of California, Los Angeles"
+    owner: "University of California, Los Angeles"
+    notes: ""
+    vm: false
+  - hostname: "tick.uh.edu"
+    AS: "AS638"
+    stratum: "Unknown"
+    location: "University of Hawaii"
+    owner: "University of Hawaii"
+    notes: ""
+    vm: false
+  - hostname: "ntpstm.netbone-digital.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "NetBone Digital"
+    owner: "NetBone Digital"
+    notes: ""
+    vm: false
+  - hostname: "nist1.symmetricom.com"
+    AS: "AS3608"
+    stratum: 1
+    location: "Microsemi/Symmetricom"
+    owner: "Microsemi"
+    notes: ""
+    vm: false
+  - hostname: "ntp.quintex.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "Quintex"
+    owner: "Quintex"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.conectiv.com"
+    AS: "AS16069"
+    stratum: "Unknown"
+    location: "Conectiv"
+    owner: "Conectiv"
+    notes: ""
+    vm: false
+  - hostname: "tock.usshc.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "USSHC"
+    owner: "USSHC"
+    notes: ""
+    vm: false
+  - hostname: "t2.timegps.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "timegps.net"
+    owner: "timegps.net"
+    notes: ""
+    vm: false
+  - hostname: "gps.layer42.net"
+    AS: "AS11491"
+    stratum: "Unknown"
+    location: "Layer42"
+    owner: "Layer42"
+    notes: ""
+    vm: false
+  - hostname: "ntp-ca.stygium.net"
+    AS: "AS3978"
+    stratum: "Unknown"
+    location: "Stygium"
+    owner: "Stygium"
+    notes: ""
+    vm: false
+  - hostname: "sesku.planeacion.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "planeacion.net"
+    owner: "planeacion.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp0.nl.uu.net"
+    AS: "AS8283"
+    stratum: "Unknown"
+    location: "KPN International Carrier"
+    owner: "KPN International Carrier"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.nl.uu.net"
+    AS: "AS8283"
+    stratum: "Unknown"
+    location: "KPN International Carrier"
+    owner: "KPN International Carrier"
+    notes: ""
+    vm: false
+  - hostname: "navobs1.oar.net"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "oar.net"
+    owner: "oar.net"
+    notes: ""
+    vm: false
+  - hostname: "ntp-galway.hea.net"
+    AS: "AS1213"
+    stratum: "Unknown"
+    location: "HEAnet"
+    owner: "HEAnet"
+    notes: "Galway"
+    vm: false
+  - hostname: "ntp1.ona.org"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "ona.org"
+    owner: "ona.org"
+    notes: ""
+    vm: false
+  - hostname: "ntp.your.org"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "your.org"
+    owner: "your.org"
+    notes: ""
+    vm: false
+  - hostname: "ntp.mrow.org"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "mrow.org"
+    owner: "mrow.org"
+    notes: ""
+    vm: false
+  - hostname: "time.fu-berlin.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "Freie Universitaet Berlin"
+    notes: ""
+    vm: false
+  - hostname: "ntps1-0.cs.tu-berlin.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "Technische Universitaet Berlin"
+    notes: ""
+    vm: false
+  - hostname: "ntps1-1.cs.tu-berlin.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "Technische Universitaet Berlin"
+    notes: ""
+    vm: false
+  - hostname: "ntps1-0.uni-erlangen.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Erlangen-Nuremberg"
+    notes: ""
+    vm: false
+  - hostname: "ntps1-1.uni-erlangen.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Erlangen-Nuremberg"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.fau.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Erlangen-Nuremberg (FAU)"
+    notes: "From .de comments"
+    vm: false
+  - hostname: "ntp2.fau.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Erlangen-Nuremberg (FAU)"
+    notes: "From .de comments"
+    vm: false
+  - hostname: "ntp.dianacht.de"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "dianacht.de"
+    notes: ""
+    vm: false
+  - hostname: "zeit.fu-berlin.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "Freie Universitaet Berlin"
+    notes: ""
+    vm: false
+  - hostname: "ptbtime1.ptb.de"
+    AS: "AS1896"
+    stratum: 1
+    location: "Germany"
+    owner: "PTB"
+    notes: ""
+    vm: false
+  - hostname: "ptbtime2.ptb.de"
+    AS: "AS1896"
+    stratum: 1
+    location: "Germany"
+    owner: "PTB"
+    notes: ""
+    vm: false
+  - hostname: "rustime01.rus.uni-stuttgart.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Stuttgart"
+    notes: ""
+    vm: false
+  - hostname: "rustime02.rus.uni-stuttgart.de"
+    AS: "AS680"
+    stratum: "Unknown"
+    location: "Germany"
+    owner: "University of Stuttgart"
+    notes: ""
+    vm: false
+  - hostname: "chime1.surfnet.nl"
+    AS: "AS1103"
+    stratum: "Unknown"
+    location: "Netherlands"
+    owner: "SURFnet"
+    notes: ""
+    vm: false
+  - hostname: "ntp.vsl.nl"
+    AS: "AS34929"
+    stratum: 1
+    location: "Netherlands"
+    owner: "VSL"
+    notes: ""
+    vm: false
+  - hostname: "asynchronos.iiss.at"
+    AS: "AS8401"
+    stratum: "Unknown"
+    location: "Austria"
+    owner: "ACOnet / University of Vienna"
+    notes: ""
+    vm: false
+  - hostname: "ntp.nic.cz"
+    AS: "AS25204"
+    stratum: 2
+    location: "Czech Republic"
+    owner: "CZ.NIC"
+    notes: ""
+    vm: false
+  - hostname: "time.ufe.cz"
+    AS: "AS25192"
+    stratum: 1
+    location: "Czech Republic"
+    owner: "UFE CAS"
+    notes: ""
+    vm: false
+  - hostname: "ntp.fizyka.umk.pl"
+    AS: "AS8805"
+    stratum: "Unknown"
+    location: "Poland"
+    owner: "Nicolaus Copernicus University"
+    notes: ""
+    vm: false
+  - hostname: "tempus1.gum.gov.pl"
+    AS: "AS43900"
+    stratum: 1
+    location: "Poland"
+    owner: "GUM"
+    notes: ""
+    vm: false
+  - hostname: "tempus2.gum.gov.pl"
+    AS: "AS43900"
+    stratum: 1
+    location: "Poland"
+    owner: "GUM"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.usv.ro"
+    AS: "AS8713"
+    stratum: "Unknown"
+    location: "Romania"
+    owner: "University Stefan cel Mare Suceava"
+    notes: ""
+    vm: false
+  - hostname: "ntp3.usv.ro"
+    AS: "AS8713"
+    stratum: "Unknown"
+    location: "Romania"
+    owner: "University Stefan cel Mare Suceava"
+    notes: ""
+    vm: false
+  - hostname: "timehost.lysator.liu.se"
+    AS: "AS1653"
+    stratum: "Unknown"
+    location: "Sweden"
+    owner: "Academic Computer Club Lysator"
+    notes: ""
+    vm: false
+  - hostname: "time1.stupi.se"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "Sweden"
+    owner: "stupi.se"
+    notes: ""
+    vm: false
+  - hostname: "time.nrc.ca"
+    AS: "AS573"
+    stratum: 1
+    location: "Canada"
+    owner: "National Research Council Canada"
+    notes: ""
+    vm: false
+  - hostname: "clock.uregina.ca"
+    AS: "AS641"
+    stratum: "Unknown"
+    location: "Canada"
+    owner: "University of Regina"
+    notes: ""
+    vm: false
+  - hostname: "cronos.cenam.mx"
+    AS: "AS8017"
+    stratum: 1
+    location: "Mexico"
+    owner: "CENAM"
+    notes: ""
+    vm: false
+  - hostname: "ntp.lcf.mx"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "Mexico"
+    owner: "lcf.mx"
+    notes: ""
+    vm: false
+  - hostname: "hora.roa.es"
+    AS: "AS31007"
+    stratum: 1
+    location: "Spain"
+    owner: "ROA"
+    notes: ""
+    vm: false
+  - hostname: "minuto.roa.es"
+    AS: "AS31007"
+    stratum: 1
+    location: "Spain"
+    owner: "ROA"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.inrim.it"
+    AS: "AS29109"
+    stratum: 1
+    location: "Italy"
+    owner: "INRIM"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.inrim.it"
+    AS: "AS29109"
+    stratum: 1
+    location: "Italy"
+    owner: "INRIM"
+    notes: ""
+    vm: false
+  - hostname: "ntp1.oma.be"
+    AS: "AS5400"
+    stratum: 1
+    location: "Belgium"
+    owner: "Royal Observatory of Belgium"
+    notes: ""
+    vm: false
+  - hostname: "ntp2.oma.be"
+    AS: "AS5400"
+    stratum: 1
+    location: "Belgium"
+    owner: "Royal Observatory of Belgium"
+    notes: ""
+    vm: false
+  - hostname: "ntp.atomki.mta.hu"
+    AS: "AS197038"
+    stratum: 2
+    location: "Hungary"
+    owner: "ATOMKI"
+    notes: ""
+    vm: false
+  - hostname: "ntp.i2t.ehu.eus"
+    AS: "AS2110"
+    stratum: "Unknown"
+    location: "Basque Country"
+    owner: "University of the Basque Country (EHU)"
+    notes: ""
+    vm: false
+  - hostname: "ntp.neel.ch"
+    AS: "AS34569"
+    stratum: "Unknown"
+    location: "Switzerland"
+    owner: "Neel Engineering"
+    notes: ""
+    vm: false
+  - hostname: "ntp.neu.edu.cn"
+    AS: "AS4538"
+    stratum: "Unknown"
+    location: "China"
+    owner: "Northeastern University"
+    notes: ""
+    vm: false
+  - hostname: "ntps1.pads.ufrj.br"
+    AS: "AS1553"
+    stratum: "Unknown"
+    location: "Brazil"
+    owner: "Federal University of Rio de Janeiro"
+    notes: ""
+    vm: false
+  - hostname: "ntp.shoa.cl"
+    AS: "AS16299"
+    stratum: 1
+    location: "Chile"
+    owner: "Hydrographic and Oceanographic Service of the Chilean Navy"
+    notes: ""
+    vm: false
+  - hostname: "time.esa.int"
+    AS: "AS15559"
+    stratum: "Unknown"
+    location: "International"
+    owner: "European Space Agency"
+    notes: ""
+    vm: false
+  - hostname: "time1.esa.int"
+    AS: "AS15559"
+    stratum: "Unknown"
+    location: "International"
+    owner: "European Space Agency"
+    notes: ""
+    vm: false
+  - hostname: "ntp.day.ir"
+    AS: "AS42337"
+    stratum: "Unknown"
+    location: "Iran"
+    owner: "Day ICT"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp.ubuntu.com"
+    AS: "AS201815"
+    stratum: 2
+    location: "Ubuntu"
+    owner: "Canonical"
+    notes: "From comments, Anycast"
+    vm: false
+  - hostname: "ntp.viarouge.net"
+    AS: "AS207288"
+    stratum: "Unknown"
+    location: "France"
+    owner: "Hubert Viarouge"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp1.dmz.terryburton.co.uk"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Terry Burton"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp2.dmz.terryburton.co.uk"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Terry Burton"
+    notes: "From comments"
+    vm: false
+  - hostname: "time1.ntp.hr"
+    AS: "AS49932"
+    stratum: "Unknown"
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments"
+    vm: false
+  - hostname: "time2.ntp.hr"
+    AS: "AS49932"
+    stratum: "Unknown"
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments"
+    vm: false
+  - hostname: "os.ntp.carnet.hr"
+    AS: "AS49932"
+    stratum: 2
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments, Stratum 2"
+    vm: false
+  - hostname: "ri.ntp.carnet.hr"
+    AS: "AS49932"
+    stratum: 2
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments, Stratum 2"
+    vm: false
+  - hostname: "st.ntp.carnet.hr"
+    AS: "AS49932"
+    stratum: 2
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments, Stratum 2"
+    vm: false
+  - hostname: "zg1.ntp.carnet.hr"
+    AS: "AS49932"
+    stratum: 2
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments, Stratum 2"
+    vm: false
+  - hostname: "zg2.ntp.carnet.hr"
+    AS: "AS49932"
+    stratum: 2
+    location: "Croatia"
+    owner: "CARNET"
+    notes: "From comments, Stratum 2"
+    vm: false
+  - hostname: "stdtime.gov.hk"
+    AS: "AS4780"
+    stratum: 1
+    location: "Hong Kong"
+    owner: "Hong Kong Observatory"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp5.leontp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Leo Bodnar"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp6.leontp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Leo Bodnar"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp7.leontp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Leo Bodnar"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp8.leontp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Leo Bodnar"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp9.leontp.com"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Leo Bodnar"
+    notes: "From comments"
+    vm: false
+  - hostname: "timekeeper.webwiz.net"
+    AS: "AS44929"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "Web Wiz"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp.theitman.uk"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "TheITMan"
+    notes: "From comments"
+    vm: false
+  - hostname: "eshail.batc.org.uk"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "UK"
+    owner: "BATC"
+    notes: "From comments"
+    vm: false
+  - hostname: "ntp.heppen.be"
+    AS: "Unknown"
+    stratum: "Unknown"
+    location: "Belgium"
+    owner: "ON5HB Ham-radio users"
+    notes: "From comments"
+    vm: false
+  - hostname: "time.xtracloud.net"
+    AS: "AS174"
+    stratum: "Unknown"
+    location: "Qualcomm"
+    owner: "Qualcomm"
+    notes: "From comments"
+    vm: false

--- a/ntp.toml
+++ b/ntp.toml
@@ -1,0 +1,1153 @@
+#
+# NTS servers in ntpd-rs format - Modified to standard NTP server mode
+#
+
+# Google Public NTP
+[[source]]
+mode = "server"
+address = "time.google.com"
+
+[[source]]
+mode = "server"
+address = "time1.google.com"
+
+[[source]]
+mode = "server"
+address = "time2.google.com"
+
+[[source]]
+mode = "server"
+address = "time3.google.com"
+
+[[source]]
+mode = "server"
+address = "time4.google.com"
+
+[[source]]
+mode = "server"
+address = "time.android.com"
+
+
+# public Amazon Time Sync Service
+[[source]]
+mode = "server"
+address = "time.aws.com"
+
+[[source]]
+mode = "server"
+address = "amazon.pool.ntp.org"
+
+[[source]]
+mode = "server"
+address = "0.amazon.pool.ntp.org"
+
+[[source]]
+mode = "server"
+address = "1.amazon.pool.ntp.org"
+
+[[source]]
+mode = "server"
+address = "2.amazon.pool.ntp.org"
+
+[[source]]
+mode = "server"
+address = "3.amazon.pool.ntp.org"
+
+
+# Cloudflare NTP
+[[source]]
+mode = "server"
+address = "time.cloudflare.com"
+
+
+# Facebook NTP
+[[source]]
+mode = "server"
+address = "time.facebook.com"
+
+[[source]]
+mode = "server"
+address = "time1.facebook.com"
+
+[[source]]
+mode = "server"
+address = "time2.facebook.com"
+
+[[source]]
+mode = "server"
+address = "time3.facebook.com"
+
+[[source]]
+mode = "server"
+address = "time4.facebook.com"
+
+[[source]]
+mode = "server"
+address = "time5.facebook.com"
+
+
+# Microsoft NTP server
+[[source]]
+mode = "server"
+address = "time.windows.com"
+
+
+# Apple NTP server
+[[source]]
+mode = "server"
+address = "time.apple.com"
+
+[[source]]
+mode = "server"
+address = "time-macos.apple.com"
+
+[[source]]
+mode = "server"
+address = "time-ios.apple.com"
+
+[[source]]
+mode = "server"
+address = "time1.apple.com"
+
+[[source]]
+mode = "server"
+address = "time2.apple.com"
+
+[[source]]
+mode = "server"
+address = "time3.apple.com"
+
+[[source]]
+mode = "server"
+address = "time4.apple.com"
+
+[[source]]
+mode = "server"
+address = "time5.apple.com"
+
+[[source]]
+mode = "server"
+address = "time6.apple.com"
+
+[[source]]
+mode = "server"
+address = "time7.apple.com"
+
+[[source]]
+mode = "server"
+address = "time.euro.apple.com"
+
+[[source]]
+mode = "server"
+address = "time.asia.apple.com"
+
+
+# DEC/Compaq/HP
+[[source]]
+mode = "server"
+address = "clepsydra.dec.com"
+
+[[source]]
+mode = "server"
+address = "clepsydra.labs.hp.com"
+
+[[source]]
+mode = "server"
+address = "clepsydra.hpl.hp.com"
+
+[[source]]
+mode = "server"
+address = "usno.labs.hp.com"
+
+
+# NIST Internet Time Service (ITS)
+[[source]]
+mode = "server"
+address = "time-a-g.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-b-g.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-c-g.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-d-g.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-a-wwv.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-b-wwv.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-c-wwv.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-d-wwv.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-a-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-b-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-c-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-d-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-e-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-e-g.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-e-wwv.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-nw.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-a.nist.gov"
+
+[[source]]
+mode = "server"
+address = "time-b.nist.gov"
+
+[[source]]
+mode = "server"
+address = "utcnist.colorado.edu"
+
+[[source]]
+mode = "server"
+address = "utcnist2.colorado.edu"
+
+
+# VNIIFTRI
+[[source]]
+mode = "server"
+address = "ntp1.vniiftri.ru"
+
+[[source]]
+mode = "server"
+address = "ntp2.vniiftri.ru"
+
+[[source]]
+mode = "server"
+address = "ntp3.vniiftri.ru"
+
+[[source]]
+mode = "server"
+address = "ntp4.vniiftri.ru"
+
+[[source]]
+mode = "server"
+address = "ntp.sstf.nsk.ru"
+
+[[source]]
+mode = "server"
+address = "ntp1.niiftri.irkutsk.ru"
+
+[[source]]
+mode = "server"
+address = "ntp2.niiftri.irkutsk.ru"
+
+[[source]]
+mode = "server"
+address = "vniiftri.khv.ru"
+
+[[source]]
+mode = "server"
+address = "vniiftri2.khv.ru"
+
+[[source]]
+mode = "server"
+address = "ntp21.vniiftri.ru"
+
+
+# Mobatime
+[[source]]
+mode = "server"
+address = "ntp.mobatime.ru"
+
+
+# NTP SERVERS
+[[source]]
+mode = "server"
+address = "ntp0.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp1.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp2.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp3.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp4.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp5.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp6.ntp-servers.net"
+
+[[source]]
+mode = "server"
+address = "ntp7.ntp-servers.net"
+
+
+# Stratum 1 Russia
+[[source]]
+mode = "server"
+address = "ntp1.stratum1.ru"
+
+[[source]]
+mode = "server"
+address = "ntp2.stratum1.ru"
+
+[[source]]
+mode = "server"
+address = "ntp3.stratum1.ru"
+
+[[source]]
+mode = "server"
+address = "ntp4.stratum1.ru"
+
+[[source]]
+mode = "server"
+address = "ntp5.stratum1.ru"
+
+
+# Stratum 2 Russia
+[[source]]
+mode = "server"
+address = "ntp1.stratum2.ru"
+
+[[source]]
+mode = "server"
+address = "ntp2.stratum2.ru"
+
+[[source]]
+mode = "server"
+address = "ntp3.stratum2.ru"
+
+[[source]]
+mode = "server"
+address = "ntp4.stratum2.ru"
+
+[[source]]
+mode = "server"
+address = "ntp5.stratum2.ru"
+
+
+# stratum1.net
+[[source]]
+mode = "server"
+address = "stratum1.net"
+
+
+# time.in.ua
+[[source]]
+mode = "server"
+address = "ntp.time.in.ua"
+
+[[source]]
+mode = "server"
+address = "ntp2.time.in.ua"
+
+[[source]]
+mode = "server"
+address = "ntp3.time.in.ua"
+
+
+# Company Delfa Co. Ltd.
+[[source]]
+mode = "server"
+address = "ntp.ru"
+
+
+# ACO.net
+[[source]]
+mode = "server"
+address = "ts1.aco.net"
+
+[[source]]
+mode = "server"
+address = "ts2.aco.net"
+
+
+# Berkeley
+[[source]]
+mode = "server"
+address = "ntp1.net.berkeley.edu"
+
+[[source]]
+mode = "server"
+address = "ntp2.net.berkeley.edu"
+
+
+# Georgia State University
+[[source]]
+mode = "server"
+address = "ntp.gsu.edu"
+
+
+# University of Saskatchewan
+[[source]]
+mode = "server"
+address = "tick.usask.ca"
+
+[[source]]
+mode = "server"
+address = "tock.usask.ca"
+
+
+# NSU
+[[source]]
+mode = "server"
+address = "ntp.nsu.ru"
+
+
+# ITAEC
+[[source]]
+mode = "server"
+address = "ntp.psn.ru"
+
+
+# RSU
+[[source]]
+mode = "server"
+address = "ntp.rsu.edu.ru"
+
+
+# National Institute of Information and Communications Technology
+[[source]]
+mode = "server"
+address = "ntp.nict.jp"
+
+
+# INTERNET MULTIFEED CO.
+[[source]]
+mode = "server"
+address = "ntp1.jst.mfeed.ad.jp"
+
+[[source]]
+mode = "server"
+address = "ntp2.jst.mfeed.ad.jp"
+
+[[source]]
+mode = "server"
+address = "ntp3.jst.mfeed.ad.jp"
+
+
+# NTT
+[[source]]
+mode = "server"
+address = "x.ns.gin.ntt.net"
+
+[[source]]
+mode = "server"
+address = "y.ns.gin.ntt.net"
+
+
+# HE.net Public Stratum 1 NTP servers
+[[source]]
+mode = "server"
+address = "clock.sjc.he.net"
+
+[[source]]
+mode = "server"
+address = "clock.fmt.he.net"
+
+[[source]]
+mode = "server"
+address = "clock.nyc.he.net"
+
+
+# TRC Fiord
+[[source]]
+mode = "server"
+address = "ntp.fiord.ru"
+
+
+# Netnod NTP service
+[[source]]
+mode = "server"
+address = "gbg1.ntp.se"
+
+[[source]]
+mode = "server"
+address = "gbg2.ntp.se"
+
+[[source]]
+mode = "server"
+address = "mmo1.ntp.se"
+
+[[source]]
+mode = "server"
+address = "mmo2.ntp.se"
+
+[[source]]
+mode = "server"
+address = "sth1.ntp.se"
+
+[[source]]
+mode = "server"
+address = "sth2.ntp.se"
+
+[[source]]
+mode = "server"
+address = "svl1.ntp.se"
+
+[[source]]
+mode = "server"
+address = "svl2.ntp.se"
+
+[[source]]
+mode = "server"
+address = "ntp.se"
+
+
+# QiX NTP
+[[source]]
+mode = "server"
+address = "ntp.qix.ca"
+
+[[source]]
+mode = "server"
+address = "ntp1.qix.ca"
+
+[[source]]
+mode = "server"
+address = "ntp2.qix.ca"
+
+
+# YYCIX NTP
+[[source]]
+mode = "server"
+address = "ntp.yycix.ca"
+
+
+# MSK-IX NTP
+[[source]]
+mode = "server"
+address = "ntp.ix.ru"
+
+
+# Hetzner Online
+[[source]]
+mode = "server"
+address = "ntp1.hetzner.de"
+
+[[source]]
+mode = "server"
+address = "ntp2.hetzner.de"
+
+[[source]]
+mode = "server"
+address = "ntp3.hetzner.de"
+
+
+# Trabia-Network
+[[source]]
+mode = "server"
+address = "time-a.as43289.net"
+
+[[source]]
+mode = "server"
+address = "time-b.as43289.net"
+
+[[source]]
+mode = "server"
+address = "time-c.as43289.net"
+
+
+# RIPE
+[[source]]
+mode = "server"
+address = "ntp.ripe.net"
+
+
+# Internet Systems Consortium
+[[source]]
+mode = "server"
+address = "clock.isc.org"
+
+
+# TimeNL/SIDN Labs
+[[source]]
+mode = "server"
+address = "ntp.time.nl"
+
+[[source]]
+mode = "server"
+address = "ntppool1.time.nl"
+
+[[source]]
+mode = "server"
+address = "ntppool2.time.nl"
+
+
+# Kantonsschule Zug
+[[source]]
+mode = "server"
+address = "ntp0.as34288.net"
+
+[[source]]
+mode = "server"
+address = "ntp1.as34288.net"
+
+
+# Chinese Academy of Sciences Nation Time Service Center
+[[source]]
+mode = "server"
+address = "ntp.ntsc.ac.cn"
+
+
+# Nat Morris
+[[source]]
+mode = "server"
+address = "ntp.nat.ms"
+
+
+# US Naval Observatory
+[[source]]
+mode = "server"
+address = "tick.usno.navy.mil"
+
+[[source]]
+mode = "server"
+address = "tock.usno.navy.mil"
+
+[[source]]
+mode = "server"
+address = "ntp2.usno.navy.mil"
+
+
+# ISI
+[[source]]
+mode = "server"
+address = "timekeeper.isi.edu"
+
+
+# University of Delaware
+[[source]]
+mode = "server"
+address = "rackety.udel.edu"
+
+[[source]]
+mode = "server"
+address = "mizbeaver.udel.edu"
+
+
+# Pennsylvania State University
+[[source]]
+mode = "server"
+address = "otc1.psu.edu"
+
+
+# Columbia University
+[[source]]
+mode = "server"
+address = "gnomon.cc.columbia.edu"
+
+
+# Georgia Institute of Technology
+[[source]]
+mode = "server"
+address = "navobs1.gatech.edu"
+
+
+# Washington University in St. Louis
+[[source]]
+mode = "server"
+address = "navobs1.wustl.edu"
+
+
+# Oklahoma State University
+[[source]]
+mode = "server"
+address = "now.okstate.edu"
+
+
+# Colby College
+[[source]]
+mode = "server"
+address = "ntp.colby.edu"
+
+
+# University of Florida
+[[source]]
+mode = "server"
+address = "ntp-s1.cise.ufl.edu"
+
+
+# MIT LCS
+[[source]]
+mode = "server"
+address = "bonehed.lcs.mit.edu"
+
+
+# University of North Carolina at Chapel Hill
+[[source]]
+mode = "server"
+address = "level1e.cs.unc.edu"
+
+
+# University of California, Los Angeles
+[[source]]
+mode = "server"
+address = "tick.ucla.edu"
+
+
+# University of Hawaii
+[[source]]
+mode = "server"
+address = "tick.uh.edu"
+
+
+# NetBone Digital
+[[source]]
+mode = "server"
+address = "ntpstm.netbone-digital.com"
+
+
+# Microsemi/Symmetricom
+[[source]]
+mode = "server"
+address = "nist1.symmetricom.com"
+
+
+# Quintex
+[[source]]
+mode = "server"
+address = "ntp.quintex.com"
+
+
+# Conectiv
+[[source]]
+mode = "server"
+address = "ntp1.conectiv.com"
+
+
+# USSHC
+[[source]]
+mode = "server"
+address = "tock.usshc.com"
+
+
+# timegps.net
+[[source]]
+mode = "server"
+address = "t2.timegps.net"
+
+
+# Layer42
+[[source]]
+mode = "server"
+address = "gps.layer42.net"
+
+
+# Stygium
+[[source]]
+mode = "server"
+address = "ntp-ca.stygium.net"
+
+
+# planeacion.net
+[[source]]
+mode = "server"
+address = "sesku.planeacion.net"
+
+
+# KPN International Carrier
+[[source]]
+mode = "server"
+address = "ntp0.nl.uu.net"
+
+[[source]]
+mode = "server"
+address = "ntp1.nl.uu.net"
+
+
+# oar.net
+[[source]]
+mode = "server"
+address = "navobs1.oar.net"
+
+
+# HEAnet
+[[source]]
+mode = "server"
+address = "ntp-galway.hea.net"
+
+
+# ona.org
+[[source]]
+mode = "server"
+address = "ntp1.ona.org"
+
+
+# your.org
+[[source]]
+mode = "server"
+address = "ntp.your.org"
+
+
+# mrow.org
+[[source]]
+mode = "server"
+address = "ntp.mrow.org"
+
+
+# Germany
+[[source]]
+mode = "server"
+address = "time.fu-berlin.de"
+
+[[source]]
+mode = "server"
+address = "ntps1-0.cs.tu-berlin.de"
+
+[[source]]
+mode = "server"
+address = "ntps1-1.cs.tu-berlin.de"
+
+[[source]]
+mode = "server"
+address = "ntps1-0.uni-erlangen.de"
+
+[[source]]
+mode = "server"
+address = "ntps1-1.uni-erlangen.de"
+
+[[source]]
+mode = "server"
+address = "ntp1.fau.de"
+
+[[source]]
+mode = "server"
+address = "ntp2.fau.de"
+
+[[source]]
+mode = "server"
+address = "ntp.dianacht.de"
+
+[[source]]
+mode = "server"
+address = "zeit.fu-berlin.de"
+
+[[source]]
+mode = "server"
+address = "ptbtime1.ptb.de"
+
+[[source]]
+mode = "server"
+address = "ptbtime2.ptb.de"
+
+[[source]]
+mode = "server"
+address = "rustime01.rus.uni-stuttgart.de"
+
+[[source]]
+mode = "server"
+address = "rustime02.rus.uni-stuttgart.de"
+
+
+# Netherlands
+[[source]]
+mode = "server"
+address = "chime1.surfnet.nl"
+
+[[source]]
+mode = "server"
+address = "ntp.vsl.nl"
+
+
+# Austria
+[[source]]
+mode = "server"
+address = "asynchronos.iiss.at"
+
+
+# Czech Republic
+[[source]]
+mode = "server"
+address = "ntp.nic.cz"
+
+[[source]]
+mode = "server"
+address = "time.ufe.cz"
+
+
+# Poland
+[[source]]
+mode = "server"
+address = "ntp.fizyka.umk.pl"
+
+[[source]]
+mode = "server"
+address = "tempus1.gum.gov.pl"
+
+[[source]]
+mode = "server"
+address = "tempus2.gum.gov.pl"
+
+
+# Romania
+[[source]]
+mode = "server"
+address = "ntp1.usv.ro"
+
+[[source]]
+mode = "server"
+address = "ntp3.usv.ro"
+
+
+# Sweden
+[[source]]
+mode = "server"
+address = "timehost.lysator.liu.se"
+
+[[source]]
+mode = "server"
+address = "time1.stupi.se"
+
+
+# Canada
+[[source]]
+mode = "server"
+address = "time.nrc.ca"
+
+[[source]]
+mode = "server"
+address = "clock.uregina.ca"
+
+
+# Mexico
+[[source]]
+mode = "server"
+address = "cronos.cenam.mx"
+
+[[source]]
+mode = "server"
+address = "ntp.lcf.mx"
+
+
+# Spain
+[[source]]
+mode = "server"
+address = "hora.roa.es"
+
+[[source]]
+mode = "server"
+address = "minuto.roa.es"
+
+
+# Italy
+[[source]]
+mode = "server"
+address = "ntp1.inrim.it"
+
+[[source]]
+mode = "server"
+address = "ntp2.inrim.it"
+
+
+# Belgium
+[[source]]
+mode = "server"
+address = "ntp1.oma.be"
+
+[[source]]
+mode = "server"
+address = "ntp2.oma.be"
+
+
+# Hungary
+[[source]]
+mode = "server"
+address = "ntp.atomki.mta.hu"
+
+
+# Basque Country
+[[source]]
+mode = "server"
+address = "ntp.i2t.ehu.eus"
+
+
+# Switzerland
+[[source]]
+mode = "server"
+address = "ntp.neel.ch"
+
+
+# China
+[[source]]
+mode = "server"
+address = "ntp.neu.edu.cn"
+
+
+# Brazil
+[[source]]
+mode = "server"
+address = "ntps1.pads.ufrj.br"
+
+
+# Chile
+[[source]]
+mode = "server"
+address = "ntp.shoa.cl"
+
+
+# International
+[[source]]
+mode = "server"
+address = "time.esa.int"
+
+[[source]]
+mode = "server"
+address = "time1.esa.int"
+
+
+# Iran
+[[source]]
+mode = "server"
+address = "ntp.day.ir"
+
+
+# Ubuntu
+[[source]]
+mode = "server"
+address = "ntp.ubuntu.com"
+
+
+# France
+[[source]]
+mode = "server"
+address = "ntp.viarouge.net"
+
+
+# UK
+[[source]]
+mode = "server"
+address = "ntp1.dmz.terryburton.co.uk"
+
+[[source]]
+mode = "server"
+address = "ntp2.dmz.terryburton.co.uk"
+
+
+# Croatia
+[[source]]
+mode = "server"
+address = "time1.ntp.hr"
+
+[[source]]
+mode = "server"
+address = "time2.ntp.hr"
+
+[[source]]
+mode = "server"
+address = "os.ntp.carnet.hr"
+
+[[source]]
+mode = "server"
+address = "ri.ntp.carnet.hr"
+
+[[source]]
+mode = "server"
+address = "st.ntp.carnet.hr"
+
+[[source]]
+mode = "server"
+address = "zg1.ntp.carnet.hr"
+
+[[source]]
+mode = "server"
+address = "zg2.ntp.carnet.hr"
+
+
+# Hong Kong
+[[source]]
+mode = "server"
+address = "stdtime.gov.hk"
+
+
+# UK
+[[source]]
+mode = "server"
+address = "ntp5.leontp.com"
+
+[[source]]
+mode = "server"
+address = "ntp6.leontp.com"
+
+[[source]]
+mode = "server"
+address = "ntp7.leontp.com"
+
+[[source]]
+mode = "server"
+address = "ntp8.leontp.com"
+
+[[source]]
+mode = "server"
+address = "ntp9.leontp.com"
+
+[[source]]
+mode = "server"
+address = "timekeeper.webwiz.net"
+
+[[source]]
+mode = "server"
+address = "ntp.theitman.uk"
+
+[[source]]
+mode = "server"
+address = "eshail.batc.org.uk"
+
+
+# Belgium
+[[source]]
+mode = "server"
+address = "ntp.heppen.be"
+
+
+# Qualcomm
+[[source]]
+mode = "server"
+address = "time.xtracloud.net"
+

--- a/scripts/ntpServerConvertor.py
+++ b/scripts/ntpServerConvertor.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python3
+
+import yaml
+import argparse
+import re
+import os
+
+
+def load_yaml(file_path):
+    with open(file_path, "r") as file:
+        return yaml.safe_load(file)
+
+
+def extract_hostname(hostname_field):
+    if isinstance(hostname_field, str) and hostname_field.startswith("[") and "](" in hostname_field and hostname_field.endswith(")"):
+        match = re.search(r"\[([^\]]+)\]\(.*\)", hostname_field)
+        if match:
+            return match.group(1)
+    return hostname_field
+
+
+def generate_markdown(data):
+    markdown = "## The List\n"  # Ensure this is a single line string with \n
+    markdown += "|Hostname|AS|Stratum|Location|Owner|Notes|\n"
+    markdown += "|---|---|:---:|---|---|---|\n"
+    current_location = None
+    vm_servers = []
+
+    for server in data["servers"]:
+        if server.get("vm", False):
+            vm_servers.append(server)
+            continue
+        if server["location"] != current_location:
+            if current_location is not None:
+                markdown += "||\n"
+            current_location = server["location"]
+
+        hostname = server["hostname"]
+        asn = server.get("AS", "Unknown")
+        stratum = server["stratum"]
+        location = server["location"]
+        owner = server["owner"]
+        notes = server.get("notes", "")
+        markdown += f"|{hostname}|{asn}|{stratum}|{location}|{owner}|{notes}|\n"
+
+    if vm_servers:
+        markdown += "\n\nThe following servers are known to be virtualized and may be less accurate. YMMV.\n\n"
+        markdown += "|Hostname|AS|Stratum|Location|Owner|Notes|\n"
+        markdown += "|---|---|:---:|---|---|---|\n"
+        for server in vm_servers:
+            hostname = server["hostname"]
+            asn = server.get("AS", "Unknown")
+            stratum = server["stratum"]
+            location = server["location"]
+            owner = server["owner"]
+            notes = server.get("notes", "")
+            markdown += f"|{hostname}|{asn}|{stratum}|{location}|{owner}|{notes}|\n"
+    return markdown
+
+
+def generate_chrony_conf(data):
+    chrony_conf = "#\n# NTS servers in chrony format - Modified to standard NTP\n#\n\n"
+    current_location = None
+    vm_servers = []
+
+    for server in data["servers"]:
+        if server.get("vm", False):
+            vm_servers.append(server)
+            continue
+        if server["location"] != current_location:
+            if current_location is not None:
+                chrony_conf += "\n"
+            chrony_conf += f"# {server['location']}\n"
+            current_location = server["location"]
+
+        hostname = extract_hostname(server["hostname"])
+        chrony_conf += f"server {hostname} iburst\n"
+
+    if vm_servers:
+        chrony_conf += "\n# Known VM servers (may be less accurate)\n"
+        for server in vm_servers:
+            hostname = extract_hostname(server["hostname"])
+            chrony_conf += f"server {hostname} iburst\n"
+    return chrony_conf
+
+
+def generate_ntp_toml(data):
+    ntp_toml = "#\n# NTS servers in ntpd-rs format - Modified to standard NTP server mode\n#\n\n"
+    current_location = None
+    vm_servers = []
+
+    for server in data["servers"]:
+        if server.get("vm", False):
+            vm_servers.append(server)
+            continue
+
+        if server["location"] != current_location:
+            if current_location is not None:
+                ntp_toml += "\n"
+            ntp_toml += f"# {server['location']}\n"
+            current_location = server["location"]
+
+        hostname = extract_hostname(server["hostname"])
+        ntp_toml += f'[[source]]\nmode = "server"\naddress = "{hostname}"\n\n'
+
+    if vm_servers:
+        ntp_toml += "\n# Known VM servers (may be less accurate)\n"
+        for server in vm_servers:
+            hostname = extract_hostname(server["hostname"])
+            ntp_toml += f'[[source]]\nmode = "server"\naddress = "{hostname}"\n\n'
+    return ntp_toml
+
+
+def update_readme(readme_path, new_content):
+    try:
+        with open(readme_path, "r") as file:
+            content = file.read()
+    except FileNotFoundError:
+        print(f"Warning: {readme_path} not found. Creating a new file with the content.")
+        # Ensure new_content itself forms a valid complete document if README is missing
+        full_new_content = f"## The List\n{new_content}" if not new_content.startswith("## The List") else new_content
+        with open(readme_path, "w") as file:
+            file.write(full_new_content)
+        return
+
+    start_marker = "## The List"
+    end_marker = "## Star History"
+
+    start_index = content.find(start_marker)
+
+    if start_index == -1:
+        print(f"Warning: Start marker '{start_marker}' not found in {readme_path}. Appending content to the end.")
+        updated_content = content + "\n" + start_marker + "\n" + new_content # Ensure newlines
+        with open(readme_path, "w") as file:
+            file.write(updated_content)
+        return
+
+    # Content before the start marker (inclusive of the marker itself)
+    before_start_marker = content[:start_index + len(start_marker)]
+    
+    # Find end marker after the start marker
+    end_index = content.find(end_marker, start_index + len(start_marker))
+
+    if end_index != -1:
+        # Content after the new_content (from end_marker onwards)
+        after_new_content = content[end_index:]
+        updated_content = before_start_marker + "\n" + new_content + "\n" + after_new_content
+    else:
+        print(f"Warning: End marker '{end_marker}' not found after start marker in {readme_path}. Replacing content after start marker.")
+        updated_content = before_start_marker + "\n" + new_content # Appends new_content, ensures a newline before it
+
+    with open(readme_path, "w") as file:
+        file.write(updated_content)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert NTP server data from YAML to Markdown, chrony.conf, or ntp.toml format"
+    )
+    parser.add_argument("input_file", default="ntp-sources.yml", nargs="?",
+                        help="Path to the input YAML file (default: ntp-sources.yml)")
+    args = parser.parse_args()
+    
+    try:
+        data = load_yaml(args.input_file)
+    except FileNotFoundError:
+        print(f"Error: Input file '{args.input_file}' not found.")
+        return
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML file '{args.input_file}': {e}")
+        return
+
+    readme_path = "README.md" 
+    chrony_path = "chrony.conf"
+    toml_path = "ntp.toml"
+
+    markdown_content = generate_markdown(data)
+    update_readme(readme_path, markdown_content)
+    print(f"Processed {readme_path}")
+
+    chrony_content = generate_chrony_conf(data)
+    with open(chrony_path, "w") as file:
+        file.write(chrony_content)
+    print(f"Written {chrony_path}")
+
+    toml_content = generate_ntp_toml(data)
+    with open(toml_path, "w") as file:
+        file.write(toml_content)
+    print(f"Written {toml_path}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new repository, public-ntp-servers, designed to track public NTP servers and provide configuration files in various formats.

Key changes include:

-   `ntp-sources.yml`: Created by parsing a comprehensive list of NTP servers from mutin-sa's gist. This YAML file includes fields for hostname, AS (Autonomous System), stratum, location, owner, and notes.

-   `scripts/ntpServerConvertor.py`: A Python script adapted from jauderho/nts-servers. This script processes `ntp-sources.yml` to generate:
    -   `README.md`: An updated README file with a table of the NTP servers.
    -   `chrony.conf`: A configuration file for the chrony NTP client, listing servers with the `iburst` option (NTS explicitly excluded).
    -   `ntp.toml`: A configuration file for ntpd-rs, listing servers with `mode = "server"`.

-   `README.md`: An initial README file providing an overview of the repository and including the generated list of servers.

The script handles the extraction of server details, formatting for different client configurations, and inclusion of AS information in the main server list.