### PR TITLE
Fix(ntp): Update ntp.teambelgium.net details

### DIFF
--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -631,6 +631,14 @@ servers:
   notes: ''
   vm: false
 
+- hostname: ntp.teambelgium.net
+  AS: AS5432
+  stratum: 2
+  location: Belgium
+  owner: Team Belgium
+  notes: ''
+  vm: false
+
 - hostname: ntps1.pads.ufrj.br
   AS: AS1553
   stratum: 1


### PR DESCRIPTION
Updates the entry for ntp.teambelgium.net in ntp-sources.yml:
- Sets AS to AS5432 (Proximus NV).
- Sets stratum to 2.
- Corrects location to "Belgium".
- Clears the notes field.
- Ensures placement is after ntp2.oma.be.

This addresses the feedback you provided on the initial addition.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `ntp.teambelgium.net` details in `ntp-sources.yml`, including AS, stratum, location, and entry order.
> 
>   - **Behavior**:
>     - Updates `ntp.teambelgium.net` in `ntp-sources.yml`:
>       - Sets AS to `AS5432`.
>       - Sets stratum to `2`.
>       - Corrects location to `Belgium`.
>       - Clears the `notes` field.
>       - Ensures placement after `ntp2.oma.be`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fpublic-ntp-servers&utm_source=github&utm_medium=referral)<sup> for 1c5b040c9bb0e381233dd756302edcc0dba9993a. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->