### PR TITLE
Add tick.espanix.net and tock.espanix.net as NTP servers.

### DIFF
--- a/chrony.conf
+++ b/chrony.conf
@@ -284,6 +284,8 @@ server ntp21.vniiftri.ru iburst
 # Spain
 server hora.roa.es iburst
 server minuto.roa.es iburst
+server tick.espanix.net iburst
+server tock.espanix.net iburst
 
 # Sweden
 server timehost.lysator.liu.se iburst

--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -1375,6 +1375,22 @@ servers:
   notes: ''
   vm: false
 
+- hostname: tick.espanix.net
+  AS: Unknown
+  stratum: 1
+  location: Spain
+  owner: Espanix
+  notes: ''
+  vm: false
+
+- hostname: tock.espanix.net
+  AS: Unknown
+  stratum: 1
+  location: Spain
+  owner: Espanix
+  notes: ''
+  vm: false
+
 - hostname: timehost.lysator.liu.se
   AS: AS1653
   stratum: Unknown

--- a/ntp.toml
+++ b/ntp.toml
@@ -797,6 +797,14 @@ address = "hora.roa.es"
 mode = "server"
 address = "minuto.roa.es"
 
+[[source]]
+mode = "server"
+address = "tick.espanix.net"
+
+[[source]]
+mode = "server"
+address = "tock.espanix.net"
+
 
 # Sweden
 [[source]]


### PR DESCRIPTION
These are new Stratum 1 NTP servers located in Spain.

I've updated the following files with this information:
- chrony.conf
- ntp-sources.yml
- ntp.toml

From https://gist.github.com/mutin-sa/eea1c396b1e610a2da1e5550d94b0453?permalink_comment_id=5608848#gistcomment-5608848