### PR TITLE
Add India NTP servers

### DIFF
--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -1934,3 +1934,43 @@ servers:
   owner: Washington University in St. Louis
   notes: ''
   vm: false
+
+- hostname: time.nplindia.org
+  AS: Unknown
+  stratum: 1
+  location: India
+  owner: NPL India
+  notes: ''
+  vm: false
+
+- hostname: time.nplindia.in
+  AS: Unknown
+  stratum: 1
+  location: India
+  owner: NPL India
+  notes: ''
+  vm: false
+
+- hostname: samay1.nic.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: NIC India
+  notes: ''
+  vm: false
+
+- hostname: samay2.nic.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: NIC India
+  notes: ''
+  vm: false
+
+- hostname: ntp.iitb.ac.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: IIT Bombay
+  notes: ''
+  vm: false

--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -959,6 +959,46 @@ servers:
   notes: ''
   vm: false
 
+- hostname: time.nplindia.org
+  AS: Unknown
+  stratum: 1
+  location: India
+  owner: NPL India
+  notes: ''
+  vm: false
+
+- hostname: time.nplindia.in
+  AS: Unknown
+  stratum: 1
+  location: India
+  owner: NPL India
+  notes: ''
+  vm: false
+
+- hostname: samay1.nic.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: NIC India
+  notes: ''
+  vm: false
+
+- hostname: samay2.nic.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: NIC India
+  notes: ''
+  vm: false
+
+- hostname: ntp.iitb.ac.in
+  AS: Unknown
+  stratum: 2
+  location: India
+  owner: IIT Bombay
+  notes: ''
+  vm: false
+
 - hostname: time.esa.int
   AS: AS15559
   stratum: 1
@@ -1932,45 +1972,5 @@ servers:
   stratum: 1
   location: US
   owner: Washington University in St. Louis
-  notes: ''
-  vm: false
-
-- hostname: time.nplindia.org
-  AS: Unknown
-  stratum: 1
-  location: India
-  owner: NPL India
-  notes: ''
-  vm: false
-
-- hostname: time.nplindia.in
-  AS: Unknown
-  stratum: 1
-  location: India
-  owner: NPL India
-  notes: ''
-  vm: false
-
-- hostname: samay1.nic.in
-  AS: Unknown
-  stratum: 2
-  location: India
-  owner: NIC India
-  notes: ''
-  vm: false
-
-- hostname: samay2.nic.in
-  AS: Unknown
-  stratum: 2
-  location: India
-  owner: NIC India
-  notes: ''
-  vm: false
-
-- hostname: ntp.iitb.ac.in
-  AS: Unknown
-  stratum: 2
-  location: India
-  owner: IIT Bombay
   notes: ''
   vm: false


### PR DESCRIPTION
Add entries referenced in https://gist.github.com/mutin-sa/eea1c396b1e610a2da1e5550d94b0453?permalink_comment_id=5626692#gistcomment-5626692

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new NTP server entries for India to `ntp-sources.yml`, including servers from NPL India, NIC India, and IIT Bombay.
> 
>   - **Additions**:
>     - Add `time.nplindia.org` and `time.nplindia.in` as stratum 1 servers for NPL India.
>     - Add `samay1.nic.in` and `samay2.nic.in` as stratum 2 servers for NIC India.
>     - Add `ntp.iitb.ac.in` as a stratum 2 server for IIT Bombay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fpublic-ntp-servers&utm_source=github&utm_medium=referral)<sup> for 8cbeb315228179bd2a57f689d28fb51064317d8e. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->