### PR TITLE
Add Wiktel and MBIX NTP servers

### DIFF
--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -1728,3 +1728,17 @@ servers:
   owner: Washington University in St. Louis
   notes: ''
   vm: false
+- hostname: '[ntp1.wiktel.com](https://ntp1.wiktel.com)'
+  AS: AS33362
+  stratum: 1
+  location: US
+  owner: Wikstrom Telephone Company
+  notes: ''
+  vm: false
+- hostname: '[ntp2.wiktel.com](https://ntp2.wiktel.com)'
+  AS: AS33362
+  stratum: 1
+  location: US
+  owner: Wikstrom Telephone Company
+  notes: ''
+  vm: false

--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -566,6 +566,27 @@ servers:
   owner: Federal University of Rio de Janeiro
   notes: ''
   vm: false
+- hostname: '[time1.mbix.ca](https://time1.mbix.ca)'
+  AS: AS395611
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: ''
+  vm: false
+- hostname: '[time2.mbix.ca](https://time2.mbix.ca)'
+  AS: AS395611
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: ''
+  vm: false
+- hostname: '[time3.mbix.ca](https://time3.mbix.ca)'
+  AS: AS395611
+  stratum: 1
+  location: Canada
+  owner: Manitoba Internet Exchange
+  notes: ''
+  vm: false
 - hostname: time.nrc.ca
   AS: AS573
   stratum: 2


### PR DESCRIPTION
I am involved in administering these servers. (In the case of Wiktel, it's my day job. In the case of MBIX, it's a collaboration with them.) I certify that I have permission to add them to public lists.

I couldn't get the tooling to work, even after I installed asnmap. So I gave up trying to get the changes to the built files as part of this commit.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new NTP servers for Manitoba Internet Exchange and Wikstrom Telephone Company to `ntp-sources.yml`.
> 
>   - **Additions**:
>     - Added `time1.mbix.ca`, `time2.mbix.ca`, `time3.mbix.ca` with AS395611, stratum 1, located in Canada, owned by Manitoba Internet Exchange.
>     - Added `ntp1.wiktel.com`, `ntp2.wiktel.com` with AS33362, stratum 1, located in US, owned by Wikstrom Telephone Company.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fpublic-ntp-servers&utm_source=github&utm_medium=referral)<sup> for c6f1ceb9682dbec06e85883f901c2c6e02aee909. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->