### PR TITLE
Add servers under *.time.aws.com and move all *.pool.ntp.org servers to their own section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,26 @@ The list is sourced from various public resources and aims to provide configurat
 |time.android.com|AS15169|1|Google NTP|Google|Anycast|
 ||
 |time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
-|amazon.pool.ntp.org|AS14618, AS16509, AS399991|1|Amazon NTP|Amazon||
-|0.amazon.pool.ntp.org|AS14618, AS16509, AS399991|2|Amazon NTP|Amazon||
-|1.amazon.pool.ntp.org|AS14618, AS16509, AS399991|1|Amazon NTP|Amazon||
-|2.amazon.pool.ntp.org|AS14618, AS16509, AS399991|2|Amazon NTP|Amazon||
-|3.amazon.pool.ntp.org|AS14618, AS16509, AS399991|2|Amazon NTP|Amazon||
+|time0.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|time1.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|time2.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|time3.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+||
+|pool.ntp.org|||NTP global public Pool|pool.ntp.org||
+|0.pool.ntp.org|||NTP global public Pool|pool.ntp.org||
+|1.pool.ntp.org|||NTP global public Pool|pool.ntp.org||
+|2.pool.ntp.org|||NTP global public Pool|pool.ntp.org||
+|3.pool.ntp.org|||NTP global public Pool|pool.ntp.org||
+|amazon.pool.ntp.org|||NTP public Pool for Amazon|pool.ntp.org||
+|0.amazon.pool.ntp.org|||NTP public Pool for Amazon|pool.ntp.org||
+|1.amazon.pool.ntp.org|||NTP public Pool for Amazon|pool.ntp.org||
+|2.amazon.pool.ntp.org|||NTP public Pool for Amazon|pool.ntp.org||
+|3.amazon.pool.ntp.org|||NTP public Pool for Amazon|pool.ntp.org||
+|ubnt.pool.ntp.org|||NTP public Pool for Ubiquiti Unifi|pool.ntp.org||
+|0.ubnt.pool.ntp.org|||NTP public Pool for Ubiquiti Unifi|pool.ntp.org||
+|1.ubnt.pool.ntp.org|||NTP public Pool for Ubiquiti Unifi|pool.ntp.org||
+|2.ubnt.pool.ntp.org|||NTP public Pool for Ubiquiti Unifi|pool.ntp.org||
+|3.ubnt.pool.ntp.org|||NTP public Pool for Ubiquiti Unifi|pool.ntp.org||
 ||
 |time.cloudflare.com|AS13335|3|Cloudflare NTP|Cloudflare|Anycast|
 ||

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ The list is sourced from various public resources and aims to provide configurat
 |time.android.com|AS15169|1|Google NTP|Google|Anycast|
 ||
 |time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
-|time0.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
-|time1.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
-|time2.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
-|time3.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|0.time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|1.time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|2.time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
+|3.time.aws.com|AS14618, AS16509, AS399991|4|Amazon NTP|Amazon|Anycast|
 ||
 |pool.ntp.org|||NTP global public Pool|pool.ntp.org||
 |0.pool.ntp.org|||NTP global public Pool|pool.ntp.org||


### PR DESCRIPTION
I worked on the team at AWS that ran all the NTP time services for all of Amazon and AWS, and I also helped Ask Bjørn Hansen set up and administer the NTP Pool project at `pool.ntp.org` (way back in the day).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds AWS time servers and reorganizes NTP pool servers in `README.md`.
> 
>   - **Behavior**:
>     - Adds `0.time.aws.com`, `1.time.aws.com`, `2.time.aws.com`, `3.time.aws.com` under Amazon NTP section in `README.md`.
>     - Moves `*.pool.ntp.org` servers to a new section labeled "NTP global public Pool" in `README.md`.
>   - **Misc**:
>     - Reorganizes server list for better clarity and separation of AWS and NTP pool servers in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fpublic-ntp-servers&utm_source=github&utm_medium=referral)<sup> for 1e0f6fa1628d1349a3ce961088a664b564b5c792. You can [customize](https://app.ellipsis.dev/jauderho/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->