### PR TITLE
Update Canada entries: QiX is now CANIX (ntp*.yul.canix.ca)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ The list is sourced from various public resources and aims to provide configurat
 ||
 |ntps1.pads.ufrj.br|AS1553|1|Brazil|Federal University of Rio de Janeiro||
 ||
+|ntp.yul.canix.ca|AS14086|1|Canada|CANIX|Montreal|
+|ntp1.yul.canix.ca|AS14086|1|Canada|CANIX|Montreal|
+|ntp2.yul.canix.ca|AS14086|1|Canada|CANIX|Montreal|
 |[time1.mbix.ca](https://time1.mbix.ca)|AS395611|1|Canada|Manitoba Internet Exchange||
 |[time2.mbix.ca](https://time2.mbix.ca)|AS395611|1|Canada|Manitoba Internet Exchange||
 |[time3.mbix.ca](https://time3.mbix.ca)|AS395611|1|Canada|Manitoba Internet Exchange||
 |time.nrc.ca|AS573|2|Canada|National Research Council Canada||
-|ntp.qix.ca|AS14086|1|Canada|QiX||
-|ntp1.qix.ca|AS14086|1|Canada|QiX||
-|ntp2.qix.ca|AS14086|1|Canada|QiX||
 |clock.uregina.ca|AS641|1|Canada|University of Regina||
 |tick.usask.ca|AS22950|1|Canada|University of Saskatchewan||
 |tock.usask.ca|AS22950|1|Canada|University of Saskatchewan||

--- a/chrony.conf
+++ b/chrony.conf
@@ -158,13 +158,13 @@ server ntp.teambelgium.net iburst
 server ntps1.pads.ufrj.br iburst
 
 # Canada
+server ntp.yul.canix.ca iburst
+server ntp1.yul.canix.ca iburst
+server ntp2.yul.canix.ca iburst
 server time1.mbix.ca iburst
 server time2.mbix.ca iburst
 server time3.mbix.ca iburst
 server time.nrc.ca iburst
-server ntp.qix.ca iburst
-server ntp1.qix.ca iburst
-server ntp2.qix.ca iburst
 server clock.uregina.ca iburst
 server tick.usask.ca iburst
 server tock.usask.ca iburst

--- a/ntp-sources.yml
+++ b/ntp-sources.yml
@@ -647,6 +647,30 @@ servers:
   notes: ''
   vm: false
 
+- hostname: ntp.yul.canix.ca
+  AS: AS14086
+  stratum: 1
+  location: Canada
+  owner: CANIX
+  notes: Montreal
+  vm: false
+
+- hostname: ntp1.yul.canix.ca
+  AS: AS14086
+  stratum: 1
+  location: Canada
+  owner: CANIX
+  notes: Montreal
+  vm: false
+
+- hostname: ntp2.yul.canix.ca
+  AS: AS14086
+  stratum: 1
+  location: Canada
+  owner: CANIX
+  notes: Montreal
+  vm: false
+
 - hostname: '[time1.mbix.ca](https://time1.mbix.ca)'
   AS: AS395611
   stratum: 1
@@ -676,30 +700,6 @@ servers:
   stratum: 2
   location: Canada
   owner: National Research Council Canada
-  notes: ''
-  vm: false
-
-- hostname: ntp.qix.ca
-  AS: AS14086
-  stratum: 1
-  location: Canada
-  owner: QiX
-  notes: ''
-  vm: false
-
-- hostname: ntp1.qix.ca
-  AS: AS14086
-  stratum: 1
-  location: Canada
-  owner: QiX
-  notes: ''
-  vm: false
-
-- hostname: ntp2.qix.ca
-  AS: AS14086
-  stratum: 1
-  location: Canada
-  owner: QiX
   notes: ''
   vm: false
 

--- a/ntp.toml
+++ b/ntp.toml
@@ -403,6 +403,18 @@ address = "ntps1.pads.ufrj.br"
 # Canada
 [[source]]
 mode = "server"
+address = "ntp.yul.canix.ca"
+
+[[source]]
+mode = "server"
+address = "ntp1.yul.canix.ca"
+
+[[source]]
+mode = "server"
+address = "ntp2.yul.canix.ca"
+
+[[source]]
+mode = "server"
 address = "time1.mbix.ca"
 
 [[source]]
@@ -416,18 +428,6 @@ address = "time3.mbix.ca"
 [[source]]
 mode = "server"
 address = "time.nrc.ca"
-
-[[source]]
-mode = "server"
-address = "ntp.qix.ca"
-
-[[source]]
-mode = "server"
-address = "ntp1.qix.ca"
-
-[[source]]
-mode = "server"
-address = "ntp2.qix.ca"
 
 [[source]]
 mode = "server"


### PR DESCRIPTION
Closes #114.

QiX has rebranded to **CANIX (Les echanges Internet du Canada)**. This renames the three Canada entries to the canonical `canix.ca` hostnames.

### Changes

- Edited `ntp-sources.yml` only; `README.md`, `chrony.conf` and `ntp.toml` are the output of `./scripts/ntpServerConvertor.py ntp-sources.yml` with no manual edits.
- Entries moved up within the Canada block to keep the existing owner-alphabetical ordering (CANIX before Manitoba Internet Exchange).

| Was | Now |
|---|---|
| ntp.qix.ca | ntp.yul.canix.ca |
| ntp1.qix.ca | ntp1.yul.canix.ca |
| ntp2.qix.ca | ntp2.yul.canix.ca |

### Details

- **AS14086** is unchanged - the ASN is now registered as CANIX Montreal Services (formerly QiX).
- Addresses are unchanged, dual-stack:
  - `ntp1.yul.canix.ca` -> `206.126.112.211` / `2620:1f:4000:2::211`
  - `ntp2.yul.canix.ca` -> `206.126.112.212` / `2620:1f:4000:2::212`
  - `ntp.yul.canix.ca` -> both (round-robin)
- Stratum 1, not virtualized, Montreal QC. Added `Montreal` in the notes column, consistent with other multi-site operators in the list.
- The `ntp*.qix.ca` names still resolve to the same addresses as legacy aliases, but they are no longer the canonical names and shouldn't be relied on long term.

I operate these servers - happy to adjust naming or notes if you'd prefer a different convention.

- Karl Morin, Executive Director, CANIX